### PR TITLE
Remove old primary mechanic

### DIFF
--- a/1_Mechanics/01_PlayerGuide_Brief.md
+++ b/1_Mechanics/01_PlayerGuide_Brief.md
@@ -2,17 +2,19 @@
 
 ## Quick-Start Guide
 
-Your Game Master (GM) is about to play narrator to a story in which you will take part. The GM will be there to help you through the process, but the more you pick up, the more time the GM can spend crafting an amazing story with you as participant.
+Your Game Master (GM) is about to play narrator to a story in which you will take part.
+The GM will be there to help you through the process, but the more you pick up, the
+more time the GM can spend crafting an amazing story with you as participant.
 
 1. Grab a deck of playing cards, exclude Jokers, and shuffle well.
-2. When asked, you'll draw one card from this deck, add a *Modifier*, and report the
-total. Sometimes, you'll be asked to draw more than one.
-   - Sometimes your total will pass a *Difficulty Check* (DC) threshold, sometimes not.
+2. When asked, `MISSING`
+   - *Modifier*
+   - Sometimes, you'll be asked to draw more than one.
+   - *Difficulty Check* (DC)
    - Success and failure are both part of an interesting story.
 3. If you draw a King or Ace, this is a *Fate Card* and should stay in your hand. If
-not, put it in your discard pile.
-   - At any time, you can discard a Fate Card to redraw and take the new value.
-   - When Aces are used in this way, add an extra +5 to the total.
+not, put it in your discard pile. At any time, you can discard a Fate Card to redraw 
+and take the new value.
 4. You should have a character sheet with Attributes (general skills, like Agility and
 Intelligence), and specific Skills under each attribute (e.g., Finesse under Agility).
 Each Attribute and Skill has a Modifier that you add when drawing a card related to that
@@ -31,17 +33,15 @@ rules) is encouraged.
    - If your character needs a rest to recharge their Energy Points or heal, this is
    played as an Epic event with either 3 cards for a short rest or 5 cards for a long
    rest.
-8. If your group turns to violence to solve issues, the DM will announce the beginning 
+8. After a long rest, suffle your discard pile back into your deck.
+9. If your group turns to violence to solve issues, the DM will announce the beginning 
 of Combat, where you draw cards to determine turn order.
-   - You can move (up to six spaces on a grid, if present) and take up to 2 actions, in
+   - You can move (up to `MISSING` on a grid, if present) and take up to 2 actions, in
    any order.
-   - The more actions you take, the harder they will be complete. Subtract 2 from each
-   Draw when taking two actions.
+   - The more actions you take, the harder they will be complete. 
    - Your character sheet will give you optional actions take under Powers, but you can
    always try something new.
-   - If you get hit, you may be asked to make a contested check. This is an additional
-   draw you make and compare the number drawn (plus any relevant modifiers) to the
-   number drawn on the attacker's hit. You can expend a Fate card to avoid damage.
+   - If you get hit, you can expend a Fate card to avoid damage.
    - Depending on the type of attack or amount of damage, you may get Stunned, Knocked
-   Out, Blinded/Deafened or Entangled, and need to pass a check to get back to normal.
-9. Remember: having fun comes first.
+   Out, Blinded/Deafened or Entangled, and need to undo this effect
+10. Remember: having fun comes first.

--- a/1_Mechanics/01_PlayerGuide_Full.md
+++ b/1_Mechanics/01_PlayerGuide_Full.md
@@ -31,52 +31,58 @@
 
 ## What is a Tabletop Game System?
 
-A game system provides all of the rules, mechanics, and story-telling devices that are used to describe how characters interact with the world during a session. During a game session, a Game Master (GM) uses the rules laid out in a game system to set the stage for a narrative that all players collectively move forward. Moment-to-moment, the GM presents a scenario and players respond by attempting actions, either specified by the game system or wholly invented. The GM determines a player’s success and failure, and guides the group in a meaningful way. 
+A game system provides all of the rules, mechanics, and story-telling devices that are
+used to describe how characters interact with the world during a session. During a game
+session, a Game Master (GM) uses the rules laid out in a game system to set the stage
+for a narrative that all players collectively move forward. Moment-to-moment, the GM
+presents a scenario and players respond by attempting actions, either specified by the
+game system or wholly invented. The GM determines a player’s success and failure, and
+guides the group in a meaningful way. 
 
-Choosing which Tabletop Roleplaying Game (TTRPG) to play is an important step when starting an adventure and different game systems are better for different things. Common game systems include Dungeons and Dragons 5th Edition (5e) and Savage Worlds Adventure Edition (SWADE); rules, supplements, and other materials for game systems can be found in published volumes and elsewhere online. Deck of Adventures sets itself apart by swapping out dedicated many-sided dice for a standard deck of playing cards. While other TTRPGs rely on using dice to determine the results of an uncertain action, Deck of Adventures just asks you to draw a card from your deck.
+Choosing which Tabletop Roleplaying Game (TTRPG) to play is an important step when
+starting an adventure and different game systems are better for different things.
+Common game systems include Dungeons and Dragons 5th Edition (5e) and Savage Worlds
+Adventure Edition (SWADE); rules, supplements, and other materials for game systems can
+be found in published volumes and elsewhere online. Deck of Adventures sets itself
+apart by swapping out dedicated many-sided dice for a standard deck of playing cards.
+While other TTRPGs rely on using dice to determine the results of an uncertain action,
+Deck of Adventures just asks you to draw a card from your deck.
 
 ## Guiding Principles
 
 In times of uncertainty, defer to the following:
 
-1. Have fun. 2. The Game Master (GM) is both the narrator and referee. They work to
-ensure the entire group has fun. They have the final say of rulings at the table and
-will work to try and resolve disputes between players that may come up.
+1. Have fun. 
+2. The Game Master (GM) is both the narrator and referee. They work to ensure the 
+entire group has fun. They have the final say of rulings at the table and will work 
+to try and resolve disputes between players that may come up.
 
 ## The Action Deck
 
 Deck of Adventures is based around a 52-card deck: 13 cards (2-10, J, Q, K, and A)
 across 4 suits, without Jokers.
 
-1. To take any action, draw one card (or multiple at the GM's request) from your Action Deck. 
-2. Kings and Aces are Fate Cards and should be reserved in your hand. All other cards go
-directly into a discard pile.
-3. When the Action Deck is empty, or if otherwise instructed by the GM, shuffle the
-discard pile into the Action Deck and resume play, holding on to any unused Fate Cards
-for future use!
+1. To take any action, `MISSING`
+2. Kings and Aces are Fate Cards and should be reserved in your hand. All other cards 
+go directly into a discard pile. Hold on to these Fate Cards, even when shuffling the deck.
+3. When the Action Deck is empty, `MISSING`
 
 Sometimes the odds will be in your favor; sometimes they will be against you. 
-1. Having the Upper Hand means you draw 2 cards and pick the highest value, after
-modifiers. The other cards is immediately discarded. This is your favor when you're
-looking for a high total.
-2. Having the Lower Hand means you draw 2 cards and pick the lower value, after
-modifiers. The other card is immediately discarded. This could represent how difficult a
-given task is for you.
-3. Having a Wild Hand means you draw 2 cards and pick whichever card you prefer. 
+1. Having the Upper Hand means you draw 2 cards and `MISSING`. The other cards is
+`MISSING`. The odds are in your favor.
+2. Having the Lower Hand means you draw 2 cards and `MISSING`. The other card is
+`MISSING`. This could represent how difficult a given task is for you.
 
 ## Fate Cards
 
 Fate Cards (K and A) are a chance to control your fate. They permit the player to choose
 when they want a second chance at a key moment.
 
-1. Fate Cards drawn from the deck are critical successes, after which the card remains
-in the player's hand.
-2. Any time a player draws a card, they may discard a held Fate Card to a drawn card and
-draw a new one.
+1. Fate Cards drawn from the deck are played as usual, but remains in the player's hand.
+2. Any time a player draws a card, they may discard a held Fate Card and redraw.
 3. A GM may award a Fate Card (as pulled from the discard pile or signified by another
 token) to a player for excellent play, including exemplifying their character’s
 strengths or weaknesses.
-4. When exchanged as a Fate Card, Aces give the next card drawn a +5 modifier. 
     
 ## Characters
 
@@ -86,13 +92,9 @@ strengths or weaknesses.
 weaknesses: Agility, Strength, Intuition, Intelligence, Conviction, and Vitality.
 2. Skills are specific to an Attribute. Athletics is a Strength skill, but Bluffing is a
 Conviction skill.
-3. Modifiers reflect a character’s level of expertise given Attribute or Skill domain,
-and are expressed as +/- modifiers ranging anywhere from -2, to +X. Modifiers are added
-to the total of the card drawn when making any check relevant to that Attribute or
-Skill.
-4. When the GM asks a player to draw a card, they may announce the corresponding skill.
-The player reports the card’s value with corresponding modifier. Totals above 10 can
-either be reported as number value or face card value (J 11; Q 12; K 13; A 14).
+3. Modifiers reflect a character’s level of expertise given Attribute or Skill domain. 
+`MISSING`
+4. Face cards retain their value relative to the 10 (J 11; Q 12; K 13; A 14).
 
 Complete list:
 - AGL Agility
@@ -123,12 +125,12 @@ Complete list:
 
 1. Dealers. All player characters, and some in-game characters. They...
    1. Can have Powers and Vulnerabilities.
-   2. Have 3 health points (HP).
+   2. Have `MISSING` health points (HP).
    3. Can receive and use Fate Cards.
 2. Bystanders. All other characters. They...
    1. Are weaker than Dealers
    2. Have limited access to Powers
-   3. Have 1 health point.
+   3. Have `MISSING` health point.
 3. Companions are creatures that can be associated with a Dealer, like a pet or other-worldly advisor. See the setting Bestiary for a list of potential Companions.
 
 ## During Play
@@ -155,31 +157,17 @@ to be rude to one’s fellow players.
 
 ### Making a Check
 
-When the GM calls for a Check, they will specify the relevant Attribute or Skill. The
-player then draws a card from their Action Deck and announces the total, plus the
-relevant Modifier. Success is determined by comparing this total to the GM’s Difficulty
-Class (DC), which the GM may or may not announce. The GM may describe the nature of the
-outcome or announce the degree of success and ask the player to describe the outcome
+When the GM calls for a Check, `MISSING` relevant Attribute or Skill. `MISSING` The GM 
+may describe the nature of the outcome or announce the degree of success and ask the 
+player to describe the outcome
 
-1. Drawing a 2 is a complete failure, regardless of Modifier. There may be immediate or
-future consequences. Unless otherwise specified, a player may not use a Fate Card to
-avoid the critical failure
-2. Drawing an Ace is a complete success regardless of DC. There may be immediate or \
-future boons associated with this success, as determined by the GM.
-3. A difference of 4 or more is a major success or failure. 
-4. A difference of between 1 and 3 is a minor success.
-5. When the total equals the DC, the check is a Match and the GM may decide that the
-player succeeds, but with drawbacks.
-
-**For example**, when jumping across a chasm at a DC 7 with no Athletics modifier:
-1. Drawing a 3 is a major failure and might be associated with consequences, such as
+**For example**, when jumping across a chasm `MISSING`:
+1. `MISSING` a major failure and might be associated with consequences, such as
 falling from a great height.
-2. Drawing a 6 is a minor failure and might result in just barely grabbing on to the far
+2. `MISSING` a minor failure and might result in just barely grabbing on to the far
 ledge with minor injuries.
-3. Drawing a 7 is a Match. The character might make it across, but drop an item in the
-process.
-4. Drawing a 9 is a minor success, performing as intended.
-5. Drawing a Q is a major success. The character might catch a glimpse of something
+3. `MISSING` a minor success, performing as intended.
+4. `MISSING` a major success. The character might catch a glimpse of something
 important in the distance during their jump.
 
 ### In Combat
@@ -197,9 +185,7 @@ moving diagonally counts as one space unless otherwise ruled by the GM.
 #### Taking Turns
 
 1. Combat order is determined by card draw. Every round, all characters draw a card to
-determine order, Ace high first, down to Two. Matching cards follow standard card game
-convention and are strongest in reverse alphabetical order of suits (Spades, Hearts,
-Diamonds, Clubs).
+`MISSING`
 2. A player may delay their turn in initiative order intentionally to co-occur with
 other players, but their turn is forfeited if they do not announce their action(s) by
 the end of the round. A GM may skip a player’s turn if they are unprepared and need more
@@ -210,42 +196,34 @@ time to think.
 On a turn, a character may (a) move, and (b) perform action(s) in any order they choose.
 Each turn represents 6 seconds of game time passing.
 
-1. **Movement** Character speed is equal to 6 spaces ± Agility modifier. The total may
-be split to occur before, after, and/or between actions.
+1. **Movement** Character speed is equal to `MISSING`. The total may be split to occur 
+before, after, and/or between actions.
 2. **Actions** In addition to their movement, players can perform up to two actions each
 turn. The first action is made without penalty. If players choose to make a second
-action, the associated check is made at a -2 penalty.
+action, `MISSING` penalty.
 3. **Standard Attacks:** Character combat actions are described on the character sheet
 are associated with the character's Primary Skill Modifier, unless otherwise noted. The
-character draws a card and applies this modifier, usually against a DC determined by the
-GM depending on what the character is trying to hit. This special DC is called Armor
-Class (AC).
+character draws a card and `MISSING` modifier.
 4. **Saving Attacks:** Some attacks require the target(s) to make a check to resist the
-effect, with the target(s) applying their relevant Skill Modifier as specified by the
-power or action.
-5. **Contested Checks**. Some actions will require both attacker and target to draw a
-card and apply a relevant modifier. The highest total wins. For example, a character may
-try to tackle an enemy to the ground. The two would make a contested check of Athletics
-vs. Finesse.
-6. **Toughening Up** - A Dealer may choose to expend one Fate Card to nullify one point
-of damage per round of combat. This is a free action and must be taken before the end of
+effect, with the target(s) `MISSING`.
+5. **Contested Checks**. Some actions will require both attacker and target to `MISSING`.
+6. **Toughening Up** - A Dealer may choose to expend one Fate Card to nullify `MISSING` damage per round of combat. This is a free action and must be taken before the end of
 the Dealer's next turn.
 
 #### Effects
 
 Some effects will impact a character over time.
-1. **Stunned** If a Dealer takes 2 or more damage in 1 hit, they make a DC 8 (+2 for
-each additional damage) conviction check at the start of their turn. If failed, they may
+1. **Stunned** If a Dealer takes `MISSING` damage in 1 hit, they `MISSING` conviction 
+check at the start of their turn. If failed, they may
 either move or make one action on their turn, not both. A major failure on this check
-leaves the Dealer unable to act.Some creatures can cause stunning effects as part of
+`MISSING`. Some creatures can cause stunning effects as part of
 their attacks.
-2. **Entangled** At the start of their turn, a Dealer makes a Strength check against the
-attribute of the creature causing the effect. If failed, they may not move on that turn.
-A critical failure prevents actions requiring arm movements.
+2. **Entangled** At the start of their turn, a Dealer `MISSING`. 
+If failed, they may not move on that turn.
+`MISSING` prevents actions requiring arm movements.
 3. **Knocked Down** Getting up prevents a Dealer from making more than 1 action on their
 turn, and their movement speed is halved.
-4. **Blinded, Deafened** At the start of their turn, a Dealer makes a conviction check
-against the spell-casting attribute of the creature causing the effect (or DC 5 if
+4. **Blinded, Deafened** At the start of their turn, a Dealer makes a `MISSING` spell-casting attribute of the creature causing the effect (or DC 5 if
 physical effect). If failed, they take a -5 penalty to any action requiring the relevant
 sense.
 6. **Outnumbered** Dealers may delay their turn to co-occur with another player Dealer.
@@ -258,16 +236,14 @@ cards to pass an unknown DC as the Great Void calls out to them.
 
 ### Health and Armor
 
-Dealers have three health points, Bystanders have 1 health point, and the health of
+Dealers have `MISSING` health points, Bystanders have `MISSING`, and the health of
 Companions is determined by the level of their Dealer. If a character is wounded beyond
 their health pool, they are Knocked Out. Armor points are an optional additional pool
 that would be removed first in the event of a wound. Both health and armor points can
 be recovered on a rest. Health is recovered with a Vitality check and Armor is
 recovered with a Knowledge or Craft check.
 
-AC is calculated by adding 8 to one of the following: Agility modifier, Vitality
-modifier, or number of Armor points remaining. AC is the highest of these three
-options.
+AC is calculated by `MISSING`.
 
 ### Epic Events
 
@@ -276,11 +252,8 @@ make a series of successes in a short time period. During an epic event...
 
 1. Players draw 5 cards. 
 2. The DM will call for a series of checks. Any subset of players may volunteer for any
-of these checks. The DC will be lowered relative to the number of players helping
-complete a check.
-3. During an individual check, players may play multiple cards as if playing the summed
-value and the suit of the highest card (or chosen suit if multiple high cards). Summed
-cards cannot result in a critical success.
+of these checks.
+3. During an individual check, players `MISSING`.
 4. Fate Cards card mechanics remain the same: played Ks and As return to the  player’s
 hand. If played as Fate Cards, they result in a number of discards and redraws equal to
 the number Fate Cards played.
@@ -294,17 +267,16 @@ react.
 
 ### Rests
 
-A rest is an epic event in which players state what they hope to accomplish over the
+A rest is an Epic Event in which players state what they hope to accomplish over the
 rest. Each goal is a separate check the players must collectively pass. Taking a short
 rest permits players to draw 3 cards, and long rest 5.
 
 During a Rest, players might attempt to repair an item (including Armor), read a book,
 recover Health Points (HP), or recover Energy Points. Recovering Health is a Vitality
-check of DC 7 + 2 for each Health Point being recovered. Some Powers are limited-use
-and require recharging associated Energy Points during a rest, at a Primary Skill DC of
-7 + 1 for each Point being recovered. A Dealer who draws below the DC indicated above
-recovers a smaller portion of Health or Energy Points equal to the number drawn minus
-7.
+check `MISSING` for each Health Point being recovered. Some Powers are limited-use
+and require recharging associated Energy Points during a rest, at a Primary Skill  
+`MISSING` for each Point being recovered. A Dealer who draws `MISSING`
+recovers a smaller portion of Health or Energy Points equal `MISSING`.
 
 Players take turns attempting their respective checks. Order is either determined by the
 players themselves or the last played initiative order. The GM determines the DC for
@@ -320,7 +292,7 @@ Experience Points on Attributes, Skills, Powers, Vulnerabilities and/or Skills.
 - Attributes cost more, but also increase corresponding skills.
 - Spending points has diminishing returns. Going from 0 to +1 is relatively cheap, but
 +3 to +4 will take many more points.
-- Skill Modifiers start “unskilled,” with a -2 Modifier, so choose carefully. 
+- Skill Modifiers start “unskilled,” with a 0 Modifier, so choose carefully. 
 - Vulnerabilities are roleplay and/or combat weaknesses and yield 1 or 2 additional
 Experience Points to spend.
 - Powers are special features, boons or strengths, that cost 1 or 2 points. 

--- a/1_Mechanics/03_CharacterCreation.md
+++ b/1_Mechanics/03_CharacterCreation.md
@@ -3,17 +3,16 @@
 ## Decide Your Background
 
 First, choose where your character is coming from including your lived experiences that
-would motivate adventuring. Classically, this is a racial or species origin
-(e.g., Dwarves, Humans, or Elves of Fantasy) that fits with the GM's setting. Deck of
-Adventures offers many more backgrounds to choose from that could inspire your core
-concept. This has no inherent mechanical impact, but may shape how your character
+would motivate adventuring. Classically, this is a 'racial' or species origin
+(e.g., Dwarves, Humans, or Elves of Fantasy) that fits with the GM's setting. 
+This has no inherent mechanical impact, but may shape how your character
 navigates challenges. Growing up at a seaport or a Dwarf, your character might be more
 adept at sailing or masonry (i.e., certain skill checks) than others.
 
 ## Choose Your Role
 
 Your Role describes how your character navigates challenges. While a Defender might
-apply force, a Mage might find a more magical solution. Choosing an Role grants you
+apply force, a Caster might find a more magical solution. Choosing an Role grants you
 access to specific upgrades, called Powers. Each Role has a skill they use to attack in
 combat (e.g., Brute Strength or Knowledge). You can switch your Role later on, but must
 forfeit Powers with that prerequisite in exchange for the points previously spent.
@@ -29,7 +28,7 @@ forfeit Powers with that prerequisite in exchange for the points previously spen
    other boons to sway the battle in their favor. We're all stronger thanks to the
    support of our friends.
    - Primary Skill: Craft
-   - Suggested Suit: Hearts ♥️ / Life ❤️‍🩹
+   - Suggested Suit: Hearts ♥️ / Life ❤️‍
 - Martial
    - Description: Martials move quick and hit hard. They're adept with physical weapons
    to directly damage enemies. Agile and light on their feet!
@@ -44,34 +43,27 @@ forfeit Powers with that prerequisite in exchange for the points previously spen
 
 ## Choose your Primary Suit
 
-Roles come with primary suit suggestions, but this can be changed at each level-up. This
-won't have a direct mechanical effect at level 1, but effects will build at level 2 and
-beyond.
+Roles come with primary suit suggestions, but this can be changed at each level-up.
 
 - Diamonds ♦️ : Offense    🤛
 - Clubs    ♣️ : Defense    🛡
-- Hearts   ♥️ : Life       ❤️‍🩹
+- Hearts   ♥️ : Life       ❤️‍
 - Spades   ♠️ : Conjuring  ⚡️
 
-Starting at level 2, Dealers are given special abilities based on their primary suit.
-First, they gain an additional modifier when pulling cards of that suit. This modifier
-increases by one on each level-up. Second, they gain one of the following Suit
-Mechanics that can be used as an action a number of times equal to their level per long
-rest. Cards used in this manner are put directly in the discard pile without
-inspection. The number of cards drawn in this manner serves as an additional modifier
-on a check before the outcome is known.
+Dealers are given special abilities based on their primary suit. First, `MISSING`
+modifier. Second, `MISSING` Suit Mechanics that can be used as an action a number of
+times equal to their level per long rest. Cards used in this manner are put directly in
+the discard pile without inspection. The number of cards drawn in this manner `MISSING`.
 
 - Diamonds ♦️ : Offense Dealers have explosive damage but they run out of gas really
-fast. They can choose to *burn* up to 3 cards to add to their own attack draw.
+fast. They can choose to *burn* up to 3 cards to `MISSING` attack draw.
 - Clubs    ♣️ : Defense Dealers have a strong foundation and can take the big hits. They
-can choose to *bury* up to 3 cards to add to their own AC until the start of their next
+can choose to *bury* up to 3 cards to `MISSING` AC until the start of their next
 turn.
 - Hearts   ♥️ : Life Dealers are fluid and flexible to adapt the situation. If they are
-in the presence of an ally who fails a check, they may *toss* up to 3 cards and add that
-number to their ally's draw.
+in the presence of an ally who fails a check, they may *toss* up to 3 cards and `MISSING`
 - Spades   ♠️ : Conjuring Dealers deploy all sorts of mechanisms for drawing the eye of
-enemies away from their allies. They can *scrap* up to 3 cards and subtract that number
-from an enemy draw.
+enemies away from their allies. They can *scrap* up to 3 cards and `MISSING` enemy draw.
 
 ## Using Experience Points
 
@@ -113,12 +105,12 @@ gaining an additional Vulnerability.
 
 ### Changing Attributes and Skills
 
-All Attributes and Skills start at a +0 modifier. The Attribute modifier adds to all
-relevant Skills. You can adjust your Skills and Attributes using your Experience
+All Attributes and Skills start at a +0 modifier. The Attribute modifier  `MISSING`.
+You can adjust your Skills and Attributes using your Experience
 Points, which will help define how capable your character for relevant actions. On
 initial character creation, you can spend points to increase or gain points to decrease
-Attributes and Skill Modifiers up to positive or negative 3. This upper limit increases
-on even level-ups (2, +4; 4, +5; 6, +6). Once these are set at character creation, a
+Attributes and Skill Modifiers up to `MISSING`. This upper limit increases
+on even level-ups `MISSING`. Once these are set at character creation, a
 player may only add newly awarded Experience points.
 
 Raising an Attribute Modifier by +1 initially costs 2 Experience Points. Raising a Skill
@@ -126,17 +118,4 @@ Modifier by +1 initially costs 1 Experience Point. In both cases, raising modifi
 becomes more costly as you add. The following table shows the cost in Experience Points
 and the resulting modifier for Attributes and Skills.
 
-< center >
-| Modifier | Skill XP Cost | Attrib XP Cost |
-|     ---: |     :---:     |      :---:     |
-|       -3 |      -3       |       -8       |
-|       -2 |      -2       |       -4       |
-|       -1 |      -1       |       -2       |
-|        0 |       0       |        0       |
-|        1 |       1       |        2       |
-|        2 |       2       |        4       |
-|        3 |       3       |        8       |
-|        4 |       5       |       12       |
-|        5 |       7       |       18       |
-|        6 |       9       |       24       |
-</ center >
+`MISSING TABLE`

--- a/1_Mechanics/04_Powers.md
+++ b/1_Mechanics/04_Powers.md
@@ -49,8 +49,7 @@
    - Resource: Minor or Major
    - Mechanic: You perform you Weapon Attack on multiple characters within 1 space.
      Targets must be next to one another (i.e., no non-targets between other targets).
-     When used as a Major Power, Targets make a contested Agility check against your
-     to-hit Draw and are Knocked Down if they fail to meet the DC.
+     When used as a Major Power, Targets make `MISSING` and are Knocked Down if they fail.
    - Prerequisites: 
       + Power: Attack, Weapon
       + Role: Martial or Defender
@@ -59,9 +58,9 @@
    - Description: Ever the protector on the field, you leap at the chance to avenge an
      ally.
    - Resource: Minor or Major
-   - Mechanic: When an ally takes damage in combat, you may take 1/2(Minor/Major) Weapon
+   - Mechanic: When an ally takes damage in combat, you may take 1/2 (Minor/Major) Weapon
      Attacks against the attacker on your turn without penalty. All other actions made
-     when using this Power incur an additional -2 penalty.
+     when using this Power incur an additional `MISSING` penalty.
    - Prerequisites: 
       + Power: Attack, Weapon
       + Role: Defender
@@ -102,8 +101,8 @@
    - Mechanic: Choose one effect when you take this power:
       + You perform your Mystic Attack on all characters within a cone of 3 spaces in
         front of you.
-      + All characters in a 3 space cone in front of you make a contested Athletics
-        check against your Primary Skill. On failure, they are Knocked Down
+      + All characters in a 3 space cone in front of you make a `MISSING`.
+        On failure, they are Knocked Down
    - Prerequisites: 
       + Power: Attack, Mystic
       + Role: Caster
@@ -142,13 +141,15 @@
    - Description: Your skills allow you to deploy temporary impromptu walls
    - Resource: Minor or Major
    - Mechanic: You create a wall 3/5 (Minor/Major) spaces wide until the end of your
-     next turn. You may dismiss this wall at any time without an action.
+     next turn. You may dismiss this wall at any time without an action. This wall is 
+     impervious to standard attacks, but may be worn down over time at the GM's 
+     discretion. 
    - Prerequisites: Role: Support or Caster
    - Tags:
 - Name: Battlecharged
    - Description: You're always ready for something to go down.
    - Resource: Simple
-   - Mechanic: When drawing initiative, add +2.
+   - Mechanic: When drawing initiative, `MISSING`.
    - Prerequisites:
    - Tags:
 - Name: Calculating
@@ -157,16 +158,15 @@
    - Resource: Simple
    - Mechanic: Describe an action you or an ally wishes to take and how you would assess
      the situation. You spend 1 Power Point as you focus. Depending on your
-     description, the GM may reveal the DC of the related check in approximate
-     (e.g., above 10) or exact terms (e.g., DC of 10).
+     description, the GM may reveal `MISSING`.
    - Prerequisites: Level 2, Primary Skill: Any Intelligence Skill
    - Tags: Difficulty Prediction
 - Name: Critical Master
    - Description: When you hit big, you hit BIG. Enemies don’t stand a chance against
      you when you make a critical hit against them.
    - Resource: Simple
-   - Mechanic: When delivering a critical hit, enemies no longer get to make a contested
-     check against you. All critical hits now Stun a Dealer or Knock Out a Bystander
+   - Mechanic: When delivering a critical hit, enemies `MISSING`. All critical hits now 
+     Stun a Dealer or Knock Out a Bystander
    - Prerequisites: Level 3
    - Tags:
 - Name: Creature Connection
@@ -196,7 +196,7 @@
      to increase the creature's power. On a long rest, you train/modify your Companion
      to improve their skills.
    - Resource: Simple
-   - Mechanic: Your Companion gains one Health Point and +1 to attack Draws
+   - Mechanic: Your Companion gains `MISSING` Health Point and `MISSING` to attack.
    - Prerequisites: 
       + Level 2
       + Power: Creature Connection
@@ -205,8 +205,8 @@
    - Description: You're sharper than the rest when you take your time.
    - Resource: Simple
    - Mechanic: Choose one Attribute. On turns when you only make 1 action using a Skill
-     under that Attribute, add +1 to the relevant check. This bonus does apply to
-     contested checks initiated by another character.
+     under that Attribute, `MISSING`. This bonus does apply to contested checks 
+     initiated by another character.
    - Prerequisites:
    - Tags:
 - Name: Fated Connection
@@ -232,14 +232,14 @@
    - Mechanic: You can exchange a fate card as an automatic success, without redrawing.
    - Prerequisites: 
       + Level 2
-      + Primary Skill: Any Intuituion Skill
+      + Primary Skill: Any Intuition Skill
    - Tags: Fate Cards 🃏
 - Name: Find Weakness
    - Description: You can size up an opponent and discover their weaknesses.
    - Resource: Simple
    - Mechanic: As an action, you can make an Intuition/Detection check
-     (whichever modifier is higher) to discover an opponents vulnerability. On a DC 7
-     you learn one vulnerability and on a crit (DC 11+) you learn all vulnerabilities.
+     (whichever modifier is higher) to discover an opponents vulnerability. On a `MISSING`
+     you learn one vulnerability and on `MISSING` you learn all vulnerabilities.
    - Prerequisites: Level 2
    - Tags: Difficulty Prediction
 - Name: Focused
@@ -248,10 +248,10 @@
      barely see the outside world.
    - Resource: Simple
    - Mechanic: Pick a Skill on your character sheet. When engaged in a non-instantaneous
-     task that involves that skill, you draw 2 cards and select the higher value.
-     During this time, you also have the Unattentive Vulnerability and are also unable
-     to percieve the world outside this task. Draw 2 cards and select the lowest for
-     any Skill check made that is not directly related to the task at hand.
+     task that involves that skill, you with the Upper Hand.
+     During this time, you also have the Inattentive Vulnerability and are also unable
+     to perceive the world outside this task. Draw with the Lower Hand for any Skill 
+     check made that is not directly related to your current task.
    - Prerequisites:
    - Tags:
 - Name: Handy
@@ -259,15 +259,14 @@
      tailoring).
    - Resource: Simple
    - Mechanic: Work with your GM to decide a trade with which your character is
-     familiar. When making a check to to perform this craft, draw two cards and select
-     the higher value.
+     familiar. When making a check to to perform this craft, draw with the Upper Hand.
    - Prerequisites:
       + Skill requirement: Craft or Knowledge > +1
    - Tags: Combat
 - Name: Heal
    - Description: Can channel magical energy or medical training to heal others
    - Resource: Minor or Major
-   - Mechanic: Heal another character for 1/2 (Minor/Major) Health Points
+   - Mechanic: Heal another character for `MISSING` (Minor/Major) Health Points
    - Prerequisites: Role: Support
    - Tags:
 - Name: Illusion
@@ -275,30 +274,29 @@
    - Resource: Minor or Major
    - Mechanic: You make an illusory intangible visual (no larger than 1 space) or
      auditory effect that you've heard before. To determine if it's real, a character
-     makes a contested detection check against your Primary Skill. As a Major Power,
-     you can generate visual and auditory effects, and the check to verify draws two
-     cards, selecting the lowest value.
+     makes `MISSING`. As a Major Power,
+     you can generate visual and auditory effects, and the check to verify draws with
+     the Lower Hand.
    - Prerequisites: Role: Caster
    - Tags:
 - Name: Keen Eye
    - Description: You’re especially adept at taking in the world around you.
    - Resource: Simple
    - Mechanic: When you make a check to observe the world around you (visual, auditory
-     or olfactory), draw two cards and select the higher value.
+     or olfactory), draw with the Upper Hand.
    - Prerequisites:
    - Tags: 
 - Name: Lend Aid
    - Description: Just a little help from a friend
    - Resource: Simple
-   - Mechanic: Designate one ally who, on their next draw, will draw 2 cards and choose
-     which to use for the check. The other card is discarded.
+   - Mechanic: Designate one ally who, on their next draw, will draw with the Upper Hand.
    - Prerequisites: Role: Support
    - Tags:
 - Name: Lend Distraction
    - Description: Just an annoyance in the distance
    - Resource: Simple
-   - Mechanic: Designate a character who, on their next draw, will draw 2 cards and use
-     the lesser value. The other card is discarded
+   - Mechanic: Designate a character who, on their next draw, will draw with the Lower 
+     Hand.
    - Prerequisites: 
    - Tags:
 - Name: Lend Confusion
@@ -306,10 +304,9 @@
      target, having a sustained effect.
    - Resource: Minor or Major
    - Mechanic: Select one character to put under the effect of the Lend Distraction
-     Power. At the end of each of their turns this character can make Conviction check
-     (DC 5 + your Primary Skill modifier) to end the effect. As a Major effect, this
-     character is prevented from using Fate Cards when making their Conviction check to
-     end the effect.
+     Power. At the end of each of their turns this character `MISSING` to end the effect. 
+     As a Major effect, this character is prevented from using Fate Cards when making 
+     their check to end the effect.
    - Prerequisites: 
       + Level 2
       + Power: Lend Distraction
@@ -321,7 +318,7 @@
    - Resource: Minor or Major
    - Mechanic: Designate a character that you would like to Boost or Reduce and choose a
      Skill (or action that would require a Skill such as Attack). This character
-     receives an additional 1/2 (Minor Major) positive or negative modifier to any
+     receives an additional `MISSING` (Minor Major) positive or negative modifier to any
      Draws that involve this Skill.
    - Prerequisites: Role: Support
    - Tags:
@@ -329,8 +326,8 @@
    - Description: Your talents bolster you allies' speed and alertness.
    - Resource: Minor
    - Mechanic: Select one character. Until the end of the next combat, this character
-     draws 2 cards for initiative uses the higher value, discarding the other. This
-     effect is maintained even if you use another Power.
+     draws initiative with the Upper Hand. This  effect is maintained even if you use 
+     another Power.
    - Prerequisites: Role: Support
    - Tags: 
 - Name: Lend Vigor
@@ -353,9 +350,8 @@
    - Description: By brute strength, force others to move around the battlefield. 
    - Resource: Simple
    - Mechanic: You attempt to move a character who is within 1 space of you during your
-     movement. If the target is unwilling, this is a contested check: your Brute vs.
-     target's Finesse or Athletics, their choice. If the target fails the contested
-     check, you may place the target within 1 space of you at the end of your
+     movement. If the target is unwilling, this is `MISSING`. If the target is willing or 
+     fails the check, you may place the target within 1 space of you at the end of your
      movement.
    - Prerequisites: 
       + Role: Defender
@@ -385,13 +381,13 @@
    - Mechanic: You can a look at your top 2 cards of your deck and discard up to two of
      them. You must make a Draw before using this Power again.
    - Prerequisites: Level 2
-   - Tags: Card Viewing 👀
+   - Tags: Card Viewing 
 - Name: Shield
    - Description: Fortify yourself even further, adjusting your shield or summoning
      magical armor.
    - Size: Minor or Major
-   - Mechanic: Add +1/2 (Minor/Major) to a creature's AC until the end of their next
-     turn.
+   - Mechanic: Add `MISSING` (Minor/Major) to a creature's AC until the end of their 
+     next turn.
    - Prerequisites: Role: Support or Defender
    - Tags:
 - Name: Speed of the Wind
@@ -414,17 +410,17 @@
 - Name: Stealthy Surprise
    - Description: An undetected assailant is particularly deadly.
    - Resource: Simple
-   - Mechanic: You attempt to hide from a target. Choose a target and make a contested
-     Stealth check versus their Detection skill check. The GM does not reveal if you
+   - Mechanic: You attempt to hide from a target. Choose a target and make `MISSING` 
+     check. The GM does not reveal if you
      succeed. If successful, your next Attack Draw against that target gains an
-     additional +2 modifier so long as you are still considered hidden.
+     additional `MISSING` modifier so long as you are still considered hidden.
    - Prerequisites: Skill: Stealth > 1
    - Tags: Stealth
 - Name: Stealth in the Shadows
    - Description: A creature of the dark, you're especially adept at going unseen.
    - Resource: Simple
-   - Mechanic: When you make a Stealth check in dim light or darkness, you draw 2 cards
-     and select the higher value, discarding the other.
+   - Mechanic: When you make a Stealth check in dim light or darkness, you draw with 
+     the Upper Hand.
    - Prerequisites: Skill: Stealth > 1
    - Tags: Stealth
 - Name: Stealth's Call
@@ -432,15 +428,15 @@
      might catch you lurking.
    - Resource: Minor
    - Mechanic: You cause an illusory sound to emanate from a point you can see within 10
-     spaces. When you make a contested Stealth check versus any characters' Detection
-     check who is within 4 spaces of this point, they draw at a -2 modifier.
+     spaces. When you make a `MISSING` check versus any characters' `MISSING` within 4 
+     spaces of this point, they draw at a `MISSING` modifier.
    - Prerequisites: Skill: Stealth > 1
    - Tags: Stealth
 - Name: Stealth's Blessing
    - Description: You channel a deep energy to go unseen.
    - Resource: Minor or Major
    - Mechanic: Until your next rest, or use of a Major or Minor Power, your stealth
-     checks are made with an additional +2. If this is used as a Major power, this
+     checks are made with a `MISSING` modifier. If this is used as a Major power, this
      effect extends to up to 3 characters. This effect ends for any character who
      Attacks.
    - Prerequisites:   

--- a/1_Mechanics/04_Vulnerabilities.md
+++ b/1_Mechanics/04_Vulnerabilities.md
@@ -18,7 +18,7 @@
      exactly what you ask.
    - Resource: Minor or Major
    - Mechanic: When you draw a card to command your companion, the DM gains control of
-     the companion temporarily on cards below 3 (minor) or 4 (major)
+     the companion temporarily `MISSING` (Minor/Major)
    - Prerequisites: Power: Creature Connection
    - Tags:
 - Name: Code of Honor (a.k.a Vow, Oath)
@@ -56,8 +56,7 @@
      and you find it hard to keep up.
    - Resource: Major
    - Mechanic: When you take this Vulnerability, your combat speed is reduced by two
-     squares. When making a check to traverse terrain, draw two cards and select the
-     lower value.
+     squares. When making a check to traverse terrain, draw with the Lower Hand.
    - Prerequisites:
    - Tags:
 - Name: Illiterate
@@ -66,14 +65,23 @@
      pronounce the word.
    - Resource: Minor
    - Mechanic: You're unable to complete an action that requires understanding text.
-   - Prerequisites: Skill: Intelligence < 1
+   - Prerequisites: Skill: Intelligence `MISSING`
+   - Tags:
+- Name: Inattentive
+   - Description: You can really only do one thing at a time. The rest of the world
+     seems to fade away.
+   - Resource: Minor
+   - Mechanic: Whenever you Draw to observe or react to something you weren't already
+     aware of (e.g., Detection checks or Agility reactions), you draw with the Lower 
+     Hand.
+   - Prerequisites:
    - Tags:
 - Name: Inorganic
    - Description: You were not born, but instead created. You are not a slave to the
      bodily needs of the rest, but may instead be called to a prescribed purpose.
-   - Resource: Minor or Major
+   - Resource: Major
    - Mechanic: You do not need to breathe, eat or sleep (but still rest to recover
-     Health/Energy Points). As a Major effect, choose one of the following when you
+     Health/Energy Points). Choose one of the following when you
      take this Vulnerability:
       + Your creator or society at large consider you to have a function that you do not
         wish to pursue, such as a dangerous and laborious profession.
@@ -85,7 +93,7 @@
    - Description: An attacker has made their choice; that choice is to die.
    - Resource: Major
    - Mechanic: If you are attacked in combat, you must continue attacking until your
-     attacker is knocked out.
+     attacker is Knocked Out.
    - Prerequisites:
    - Tags:
 - Name: Outsider
@@ -93,9 +101,17 @@
      customs, somehow ostracized by the community, or even hunted based on group
      membership.
    - Resource: Minor or Major
-   - Mechanic: For any Conviction check to interact with the dominant society, you draw
-     2 cards and pick the lowest value. If chosen as Major, work with the GM to decide
+   - Mechanic: For any `MISSING` check to interact with the dominant society, you draw
+     with the Lower Hand. If chosen as Major, work with the GM to decide
      some feature of your background that makes you unwelcome in most public places.
+   - Prerequisites:
+   - Tags:
+- Name: Phobia
+   - Description: You can't shake it, there's just the terrifying fear that burdens you.
+   - Resource: GM Determined
+   - Mechanic: Work with your GM to decide a fear you hold and the reason for that fear.
+     This may be a fear of something concrete (e.g., spiders, fire) or something less
+     tangible (e.g., being alone, going hungry).
    - Prerequisites:
    - Tags:
 - Name: Savior (a.k.a Chosen One)
@@ -104,15 +120,6 @@
    - Mechanic: Work with your GM to decide a group or organization that believes you are
      the key to their salvation. You may encounter a member of this group that requires
      your help.
-   - Prerequisites:
-   - Tags:
-- Name: Unattentive
-   - Description: You can really only do one thing at a time. The rest of the world
-     seems to fade away.
-   - Resource: Minor
-   - Mechanic: Whenever you Draw to observe or react to something you weren't already
-     aware of (e.g., Detection checks or Agility reactions), you draw 2 cards and take
-     the lower value.
    - Prerequisites:
    - Tags:
 - Name: Vendetta
@@ -126,6 +133,6 @@
    - Resource: GM Determined
    - Mechanic: Work with your GM to decide an NPC or organization that thinks you’re
      responsible for a crime. You may encounter a member of this group who wants you in
-     jail or to stand trial.
+     jail, or stand trial, or outright dead.
    - Prerequisites:
    - Tags:

--- a/1_Mechanics/99_Glossary.md
+++ b/1_Mechanics/99_Glossary.md
@@ -10,7 +10,7 @@
 - [Bystander](01_PlayerGuide_Full.md#Dealers,-Bystanders-and-Companions): Less powerful
   non-player character.
 - [Check](01_PlayerGuide_Full.md#Making-a-Check): Card-draw to determine an unknown
-  outcome. A Modifier is added to the value drawn.
+  outcome. A Modifier `MISSING`.
 - [Companions](01_PlayerGuide_Full.md#Dealers,-Bystanders-and-Companions): Side-kick or
   pet for a Dealer.
 - [DC, Difficulty class/level](01_PlayerGuide_Full.md#Making-a-Check): How are is it to
@@ -18,12 +18,11 @@
 - [Dealer](01_PlayerGuide_Full.md#Dealers,-Bystanders-and-Companions): Player character
   or powerful non-player character
 - [Epic Event](01_PlayerGuide_Full.md#Epic-Events): Draw multiple cards to pass a series
-  of checks using summed totals across cards.
-- [Fate Cards](01_PlayerGuide_Full.md#Fate-Cards): King/Aces cards held for rerolls.
+  of checks using `MISSING`.
+- [Fate Cards](01_PlayerGuide_Full.md#Fate-Cards): King/Aces cards held for redraws.
 - [GM, Game Master](01_PlayerGuide_Full.md#What-is-a-Tabletop-Game-System?): narrator
   and curator of the story.
-- [Modifier](01_PlayerGuide_Full.md#Attributes,-Skills,-and-Modifiers): The number added
-  to a Check.
+- [Modifier](01_PlayerGuide_Full.md#Attributes,-Skills,-and-Modifiers): The number `MISSING`.
 - [Player](01_PlayerGuide_Full.md#What-is-a-Tabletop-Game-System?): Active participant
   in the story.
 - [Skill](01_PlayerGuide_Full.md#Attributes,-Skills,-and-Modifiers): Subskill within

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,14 +15,12 @@ multiple pages, minor and major versions will be accompanied by descriptors deta
 the nature of these changes.
 
 
-## [0.0.0b0] - Unreleased
-+ First beta release
-### Added/Removed/etc.
+## [1.0.0a0] - Unreleased
++ Revised core mechanic, from threshold to banded target.
 
 ## [0.0.0a2] - 2022-02-10
 + Changed Suit mechanic to start at Level 1 per [Issue #15]
   (https://github.com/DeckofAdventures/TheGame/issues/15)
-+ 
 
 ## [0.0.0a1] - 2022-01-14
 + Began porting notes to GitHub


### PR DESCRIPTION
- First pass to remove all the pieces related to the primary mechanic, before adding in the new target card system
- This does not yet add new components, but is a measure of consensus on our 'clean slate'
- I think we can keep epic events, yeah?
- When drawing with Upper/Lower Hand - where does the alternate card go? discarded?