### PR TITLE
Addressing Multiple Issues in PGF and GM Guide

### DIFF
--- a/docs/src/1_Mechanics/01_PlayerGuide_Brief.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Brief.md
@@ -69,7 +69,7 @@ signified by a number like +1.
 Also on your character sheet are **Powers**. This is anything your character can do
 that might not be accessible to others. Some Powers, labeled Minor and Major, take 1 or
 2 *Power Points* respectively to activate. Your character sheet shows your starting
-number of Power Points as your maximum. You'll need to keep track of how many Fate
+number of Power Points as your maximum. You'll need to keep track of how many Power
 Points you have left as you use Powers.
 
 ### Gameplay

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -425,7 +425,7 @@ poison. On a failure, they discard N+1 cards.
 Hand. A Dealer makes a DR 3 Strength Save as a Free Action at the end of their turn to
 attempt to end the freeze.
 
-9. **Suffocating** At the beginning of their turn, a Dealer makes a DR 2 Vitality Save. On a failure, take 2 damage. On a success, take 1 damage.
+9. **Suffocating** At the beginning of their turn, a Dealer makes a DR 3 Vitality Save. On a failure, take 2 damage. On a success, take 1 damage.
 
 ### Health and Armor
 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -277,9 +277,9 @@ Some checks will be initiated by a character's actions and require others to res
 pitting two skills against each other. This might be one character sneaking past
 another (e.g., Stealth vs. Detection), or one character causing a magical effect that
 another tries to dodge (e.g., Craft vs. Agility). This is a Contested Check. In these
-cases, the character who initiated the action (i.e., the Attacker) reveals a TC and
+cases, the character who initiated the action (i.e., the Attacker)
 sets the DR; the DR for a Contested Check is 3 minus half of the Attacker's relevant
-modifier, to a minimum of 0. The character(s) responding are the Target(s). Rules that
+modifier, to a minimum of 0. The character(s) responding are the Target(s), and must draw a Check against the initiator's TC. Rules that
 describe a 
 "Contested X Check vs. Y" use the attacker's Skill X and Targets' Y. Targets succeed or
 fail individually.
@@ -289,6 +289,22 @@ with deception), they would use their Bluffing Mod of +1, setting the DR to 3 (4
 They draw a TC of 3 of Diamonds, permitting a card between A and 6. Jonas draws an 8 of 
 Spades with a +1 Modifier to Detection and reports a 7, still outside the DR. Xena would 
 successfully convince Jonas of something in this scenario. 
+
+#### Saves
+
+Saves occur when a character is attempting to resist or shrug off a negative effect.
+Certain Powers, effects, or encounters may force a character to make a Save. When a
+character makes a Save, they draw a card against their own TC and use their Attribute
+Modifier for the relevant domain. A character cannot choose to use a different
+Attribute.
+
+A Save will have a DR determined by the initiator's Skill Modifier used to initiate the
+Save. The DR for a Save is 3 minus half of the initiator's relevant modifier, to a
+minimum of 0. 
+
+Saves may have different effects depending on a success or failure. This can sometimes
+mean a successful Save still results in taking damage or a negative effect. Reference a
+specific Power description for details on the effects.
 
 ### In Combat
 
@@ -375,21 +391,21 @@ Some Status Conditions will impact a character over time. The duration of each C
 is listed in the Power or effect that causes it.
 
 1. **Stunned** If a Dealer is hit by a critical attack, they make a DR 3 Conviction
-Check at the start of their turn vs their  own TC. If failed, they may either move or
+Save at the start of their turn vs their  own TC. If failed, they may either move or
 make one Action on their turn, not both. Some creatures can cause the Stunned Condition
 as part of their attacks.
 
-2. **Entangled** A Dealer may expend a Major Action to make a DR 3 Strength check. Until
-they are successful, they may not move and any Agility Checks are made with Lower
+2. **Entangled** A Dealer may expend a Major Action to make a DR 3 Strength Save. Until
+they are successful, they may not move and any Agility Saves are made with Lower
 Hand.
 
 3. **Knocked Down** A Dealer must expend a Minor Action to get up. Their movement speed
-is halved, rounding up. All Strength and Agility Checks are made with Lower Hand. When
+is halved, rounding up. All Strength and Agility Saves are made with Lower Hand. When
 Knocked Down, attackers within 1 space draw with Upper Hand and attackers further than
 1 space away draw with Lower Hand. A creature can spend 1 speed to willingly go prone as part of their movement, gaining the Knocked Down status.
 
 4. **Blinded, Deafened** At the start of their turn, as a Free Action, a Dealer makes a
-DR 3 Intuition Check vs. their TC. If they fail, they draw Lower Hand (3) for any
+DR 3 Intuition Save. If they fail, they draw Lower Hand (3) for any
 action requiring the relevant sense.
 
 5. **Knocked Out** Knocked Out (KO) Dealers are unable to act until treated by a Craft
@@ -397,15 +413,15 @@ check or a Healing Power (DR 5 vs. the KO Dealer's TC, minus 1 for each turn pas
 since the effect onset). If a Knocked Out Dealer is attacked further, the player begins
 an Epic Event alone.
 
-6. **Burned** As a Minor Action, a Dealer can make a DR 3 Intuition check to stop the
+6. **Burned** As a Minor Action, a Dealer can make a DR 3 Intuition Save to stop the
 burning. On a failure, they take 1 damage bypassing AP.
 
 7. **Poisoned N** Each poisoning effect adds +1 Poisoned. At the start of their turn, as
-a Free Action, a Dealer makes a DR 3 Vitality Check to shake off the effects of the
+a Free Action, a Dealer makes a DR 3 Vitality Save to shake off the effects of the
 poison. On a failure, they discard N+1 cards.
 
 8. **Frozen** Movement speed is reduced by half and all skill checks are drawn at Lower
-Hand. A Dealer makes a DR 3 Strength Check as a Free Action at the end of their turn to
+Hand. A Dealer makes a DR 3 Strength Save as a Free Action at the end of their turn to
 attempt to end the freeze.
 
 ### Health and Armor
@@ -609,13 +625,13 @@ creature may be covered from one direction but not from another direction.
 
 Falling from a great height is dangerous. At the end of a fall, a creature takes 1
 damage and applies -1 speed for every 2 space equivalent in height it fell and the creature is Knocked Down.
-This speed is recovered after a Rest or if the creature is healed to their maximum HP. Your GM may allow for an Agility Check to mitigate the penalty from falling.
+This speed is recovered after a Rest or if the creature is healed to their maximum HP. Your GM may allow for an Agility Save to mitigate the penalty from falling.
 
 #### Challenging Terrain
 
 Moving through the environment can sometimes be challenging. When navigating
 through *Challenging Terrain*, moving through one space requires 2 speed. While
-standing in Challenging Terrain, all Agility Checks are made with the Lower Hand. 
+standing in Challenging Terrain, all Agility Saves are made with the Lower Hand. 
 
 ## Character Creation
 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -425,7 +425,7 @@ poison. On a failure, they discard N+1 cards.
 Hand. A Dealer makes a DR 3 Strength Save as a Free Action at the end of their turn to
 attempt to end the freeze.
 
-9. **Suffocating** At the beginning of their turn, a Dealer makes a DR 2 Vitality Save. On a failure, take 2 damage. On a success, take half damage.
+9. **Suffocating** At the beginning of their turn, a Dealer makes a DR 2 Vitality Save. On a failure, take 2 damage. On a success, take 1 damage.
 
 ### Health and Armor
 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -333,7 +333,7 @@ can decide who goes first. Without consensus, the player with the higher Agility
 modifier goes first.
 
 2. A player may delay their turn in initiative order to intentionally occur before or
-after another player(s)', but their turn is forfeited if they do not announce their
+after another character(s)', but their turn is forfeited if they do not announce their
 action(s) by the end of the round. A GM may skip a player’s turn if they are unprepared
 and need more time to think.
 
@@ -377,6 +377,12 @@ others. If an action specifies a skill, this requires a check.
         - *Grapple*: Brute vs. target Finesse or Brute; cause one creature to be entangled
         - *Hide*: Stealth vs. target(s) Detection; impose Lower Hand on attacks against
          you by target(s) who failed
+
+ A character can choose to hold their Major Action to occur on a stated trigger, such
+ as "I will make an Attack, Weapon when an enemy moves within 1 space of me." If the
+ trigger occurs, the held Major Action can then be activated. If the trigger does not
+ occur before the start of the character's next turn, this Major Action is forfeited,
+ along with any Power Points used for the Major Action. 
 
 #### Ending Combat
 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -277,12 +277,12 @@ Some checks will be initiated by a character's actions and require others to res
 pitting two skills against each other. This might be one character sneaking past
 another (e.g., Stealth vs. Detection), or one character causing a magical effect that
 another tries to dodge (e.g., Craft vs. Agility). This is a Contested Check. In these
-cases, the character who initiated the action (i.e., the Attacker)
-sets the DR; the DR for a Contested Check is 3 minus half of the Attacker's relevant
-modifier, to a minimum of 0. The character(s) responding are the Target(s), and must draw a Check against the initiator's TC. Rules that
-describe a 
+cases, the character who initiated the action (i.e., the Attacker) sets the DR; the DR
+for a Contested Check is 3 minus half of the Attacker's relevant modifier, to a minimum
+of 0. The character(s) responding are the Target(s), and must draw a Check against the
+initiator's TC. Rules that describe a 
 "Contested X Check vs. Y" use the attacker's Skill X and Targets' Y. Targets succeed or
-fail individually.
+ fail individually.
 
 **For example,** Xena attempts to convince Jonas of something (either truthfully or
 with deception), they would use their Bluffing Mod of +1, setting the DR to 3 (4-1). 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -432,6 +432,8 @@ poison. On a failure, they discard N+1 cards.
 Hand. A Dealer makes a DR 3 Strength Save as a Free Action at the end of their turn to
 attempt to end the freeze.
 
+9. **Suffocating** At the beginning of their turn, a Dealer makes a DR 2 Vitality Save. On a failure, take 2 damage. On a success, take half damage.
+
 ### Health and Armor
 
 Dealers have 4 health points (HP) plus their level, plus Vitality modifier. The health
@@ -640,6 +642,16 @@ This speed is recovered after a Rest or if the creature is healed to their maxim
 Moving through the environment can sometimes be challenging. When navigating
 through *Challenging Terrain*, moving through one space requires 2 speed. While
 standing in Challenging Terrain, all Agility Saves are made with the Lower Hand. 
+
+#### Holding Breath
+
+A character can hold their breath for 1 + N number of additional minutes, where N is the
+character's Vitality Modifier. When this time runs out, or if something causes a
+character to no longer hold their breath while underwater or in a vacuum, the character
+gains the *Suffocating* Status Condition.
+
+Some Powers or effects can extend this time limit or prevent a character from
+Suffocating. 
 
 ## Character Creation
 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -374,7 +374,7 @@ others. If an action specifies a skill, this requires a check.
          you by target(s) who failed
 
  A character can choose to Ready their Major Action to occur on a stated trigger, such
- as "I will make an Attack, Weapon when an enemy moves within 1 space of me." If the
+ as "I will make a Weapon Attack when an enemy moves within 1 space of me." If the
  trigger occurs, the readied Major Action can then be activated. If the trigger does not
  occur before the start of the character's next turn, this Major Action is forfeited,
  along with any Power Points used for the Major Action. 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -373,9 +373,9 @@ others. If an action specifies a skill, this requires a check.
         - *Hide*: Stealth vs. target(s) Detection; impose Lower Hand on attacks against
          you by target(s) who failed
 
- A character can choose to hold their Major Action to occur on a stated trigger, such
+ A character can choose to Ready their Major Action to occur on a stated trigger, such
  as "I will make an Attack, Weapon when an enemy moves within 1 space of me." If the
- trigger occurs, the held Major Action can then be activated. If the trigger does not
+ trigger occurs, the readied Major Action can then be activated. If the trigger does not
  occur before the start of the character's next turn, this Major Action is forfeited,
  along with any Power Points used for the Major Action. 
 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -330,7 +330,9 @@ draw a Target Card and place it in on the table in view. The values represent th
 order (Ace first, then K, Q, etc.) and the TC for any attack. Players with the same
 Target Card values as an enemy go first. If two players draw the same Target Card, they
 can decide who goes first. Without consensus, the player with the higher Agility
-modifier goes first.
+modifier goes first. In the event of a Surprise Round, the characters who are part of
+the Surprise Round draw their TCs first and take one full round  before the characters
+being surprised draw their TCs.
 
 2. A player may delay their turn in initiative order to intentionally occur before or
 after another character(s)', but their turn is forfeited if they do not announce their

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -120,7 +120,7 @@ creative!
 
 <!--Add some examples of specific skills being used, with general description of domain --> 
 
-### Dealers, Bystanders, Minions and Companions
+### Dealers, NPCs and Companions
 
 The Player Characters (PCs) are typically the heroes of the story. PCs are
 considered Dealers and differ from the majority of other characters in the world. The
@@ -135,7 +135,7 @@ the Game Master. They...
     - Can receive and use Fate Cards.
     - Have a Primary Suit, and related mechanics.
 
-2. Bystanders and Minions. All other characters. They...
+2. NPCs. All other characters. They...
     - Are weaker than Dealers
     - Have limited access to Powers
     - Have 1-3 HP.
@@ -181,10 +181,9 @@ the circles around the bullseye.
 
 Once the DR has been announced, players must make the check. Players may consult with
 their GM to determine if another Attribute or Skill may be used instead. A player will
-draw one or more cards. Immediately after drawing, a player will apply any relevant
+draw one card from the top of their deck. Immediately after drawing, a player will apply any relevant
 Modifiers before reporting the outcome and whether or not they have successfully fallen
-within the DR. A Modifier is the maximum value a player may add or subtract; this is
-usually done to get closer to the TC. A Modifier is indicated on the character sheet
+within the DR. A Modifier is added to the DR when a check is made. A Modifier is indicated on the character sheet
 next to the relevant Skill or Attribute related to the Check. Think of it as a
 character's ability to 'aim' a check to get closer to the TC. 
 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -638,9 +638,7 @@ standing in Challenging Terrain, all Agility Saves are made with the Lower Hand.
 
 #### Holding Breath
 
-A character can hold their breath for 1 + N number of additional minutes, where N is the
-character's Vitality Modifier. When this time runs out, or if something causes a
-character to no longer hold their breath while underwater or in a vacuum, the character
+A character can go without air for 1 + 2 times Vitality Mod minutes. Taking damage without air reduces this time by 1 minute. After this time, the character
 gains the *Suffocating* Status Condition.
 
 Some Powers or effects can extend this time limit or prevent a character from

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -981,6 +981,7 @@ create your own Consumables and ask the Community for help as needed.
 | Consumable Name        | Cost  | Effect                                                                                    | Duration |
 | ---------------------- | ----- | ----------------------------------------------------------------------------------------- | -------- |
 | Potion of Healing      | 5 gp  | Regain 1 HP immediately                                                                   |          |
+| Potion of Water Breath | 10 gp | You are immune to the Suffocating Status Condition while underwater                       | 1 hour   |
 | Potion of Strength     | 15 gp | Gain +1 to all Strength-based Checks                                                      | 1 min    |
 | Potion of Agility      | 15 gp | Gain +1 to all Agility-based Checks                                                       | 1 min    |
 | Potion of Conviction   | 15 gp | Gain +1 to all Conviction-based Checks                                                    | 1 min    |

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -121,11 +121,9 @@ session to represent allies and enemies. More decks may be useful to
 represent different groups in combat. If you only have one deck available,
 split it into two 26-card decks and shuffle regularly. 
 
-One deck of cards should be designated the *Minion Deck* and one designated the *World
+One deck of cards should be designated the *NPC Deck* and one designated the *World
 Deck*. Different color card backs will help distinguish the two throughout play. The
-Minion Deck is used during combat and when applying negative [Status Conditions](./01_PlayerGuide_Full.md#status-conditions). The World Deck is used to draw Target
-Cards for NPCs, make social checks, and used for drawing a card based on a table out of
-combat. Before each Combat, reshuffle the Minion Deck. You reshuffle the World Deck
+NPC Deck is used to draw Target Cards for NPCs, for their Actions, and when applying negative [Status Conditions](./01_PlayerGuide_Full.md#status-conditions). The World Deck is used to make social checks, and to draw Target Cards representing items and objects in the world. Before each Combat, reshuffle the NPC Deck. You reshuffle the World Deck
 when it is empty. 
 
 Most NPCs won't stick around long enough to use a deck completely, and

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -984,7 +984,8 @@ create your own Consumables and ask the Community for help as needed.
 | Consumable Name        | Cost  | Effect                                                                                    | Duration |
 | ---------------------- | ----- | ----------------------------------------------------------------------------------------- | -------- |
 | Potion of Healing      | 5 gp  | Regain 1 HP immediately                                                                   |          |
-| Potion of Water Breath | 10 gp | You are immune to the Suffocating Status Condition while underwater                       | 1 hour   |
+| Potion of Water Breath | 10 gp | You are immune to the Suffocating Status Condition                                        | 1 hour   |
+| Potion of Extended Breath | 5 gp | Your ability to hold your breath is extended by 60 minutes                              | 1 hour   |
 | Potion of Strength     | 15 gp | Gain +1 to all Strength-based Checks                                                      | 1 min    |
 | Potion of Agility      | 15 gp | Gain +1 to all Agility-based Checks                                                       | 1 min    |
 | Potion of Conviction   | 15 gp | Gain +1 to all Conviction-based Checks                                                    | 1 min    |

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -123,8 +123,11 @@ split it into two 26-card decks and shuffle regularly.
 
 One deck of cards should be designated the *NPC Deck* and one designated the *World
 Deck*. Different color card backs will help distinguish the two throughout play. The
-NPC Deck is used to draw Target Cards for NPCs, for their Actions, and when applying negative [Status Conditions](./01_PlayerGuide_Full.md#status-conditions). The World Deck is used to make social checks, and to draw Target Cards representing items and objects in the world. Reshuffle the NPC Deck before each Combat. Reshuffle the World Deck
-empty. 
+NPC Deck is used to draw Target Cards for NPCs, for their Actions, and when applying
+negative [Status Conditions](./01_PlayerGuide_Full.md#status-conditions). The World
+Deck is used to make social checks, and to draw Target Cards representing items and
+objects in the world. Reshuffle the NPC Deck before each Combat. Reshuffle the World
+Deck empty. 
 
 Most NPCs won't stick around long enough to use a deck completely, and
 therefore won't shuffle prematurely, which would invoke Lower Hand on Checks.

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -392,6 +392,35 @@ described in the guide or in a Power mechanic.
 4. Arm wrestle: Brute vs. Brute
 5. Impersonation: Initiator Performance vs. Target Detection or (if suspecting) Ingestigation
 
+### Saves
+
+Saves occur when a character is attempting to resist or shrug off a negative effect(see
+[Full Player Guide](./01_PlayerGuide_Full.md#saves) for more info). Certain Powers,
+events, or encounters may force a character to make a Save. 
+
+When calling for a Save, the GM chooses the Attribute that is most relevant to the
+effect forcing the Save. A character cannot choose to use a different Attribute when
+making a Save. 
+
+When making a Save, characters draw against their own TC. This means that a Save will
+never be a Critical Success. The GM can choose to add an additional effect to a Save
+for a Major Success. 
+
+Saves may have multiple effects depending on whether a character succeeds or fails. For
+example, a Power may force a character to make an Agility save to avoid being trapped
+in entangling vines. On a failed Save, the character is Entangled. On a successful
+Save, the character avoids the vines and is not Entangled. Other Powers might do 2
+damage on a failed save, or cause half damage (1) on a successful Save. Refer to the
+specific wording of the Power to determine the effect. 
+
+Sometimes, environmental effects may force a character to make a Save. In these cases,
+the GM determines the DR and the relevant Attribute. If an effect would cause a
+character to attempt to resist it to avoid damage or a Status Condition, that character
+should make a Save.
+
+<!-- FUTURE: Add examples of Saves a character might have to make, and a relevant DR --> 
+
+
 ### Epic Events
 
 <!-- Future: revise to refer back to the same example repeatedly -->

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -396,26 +396,18 @@ described in the guide or in a Power mechanic.
 ### Saves
 
 Saves occur when a character is attempting to resist or shrug off a negative effect (see
-[Full Player Guide](./01_PlayerGuide_Full.md#saves) for more info). Certain Powers,
-events, or encounters may force a character to make a Save. 
+[Full Player Guide](./01_PlayerGuide_Full.md#saves). 
 
-When calling for a Save, the GM chooses the Attribute that is most relevant to the
-effect forcing the Save. A character cannot choose to use a different Attribute when
-making a Save. 
+When calling for a Save, choose the Attribute that is most relevant to the initiating
+effect. A character cannot choose to use a different Attribute.
 
-When making a Save, characters draw against their own TC. This means that a Save will
-never be a Critical Success. The GM can choose to add an additional effect to a Save
-for a Major Success. 
+Because characters draw against their own TC, Saves will
+never be a Critical Success. You can choose to add an additional effect to a Major Success. 
 
-Saves may have multiple effects depending on whether a character succeeds or fails. For
-example, a Power may force a character to make an Agility save to avoid being trapped
-in entangling vines. On a failed Save, the character is Entangled. On a successful
-Save, the character avoids the vines and is not Entangled. Other Powers might do 2
-damage on a failed save, or cause half damage (1) on a successful Save. Refer to the
-specific wording of the Power to determine the effect. 
+While all saves will have effects for failure, some may still have effects on success, such as half damage. Refer to the
+specific wording of the initiating effect.  
 
-Sometimes, environmental effects may force a character to make a Save. In these cases,
-the GM determines the DR and the relevant Attribute. If an effect would cause a
+If an environmental effect initiates a Save, you determine the DR and Attribute as the GM. If an effect would cause a
 character to attempt to resist it to avoid damage or a Status Condition, that character
 should make a Save.
 

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -123,8 +123,8 @@ split it into two 26-card decks and shuffle regularly.
 
 One deck of cards should be designated the *NPC Deck* and one designated the *World
 Deck*. Different color card backs will help distinguish the two throughout play. The
-NPC Deck is used to draw Target Cards for NPCs, for their Actions, and when applying negative [Status Conditions](./01_PlayerGuide_Full.md#status-conditions). The World Deck is used to make social checks, and to draw Target Cards representing items and objects in the world. Before each Combat, reshuffle the NPC Deck. You reshuffle the World Deck
-when it is empty. 
+NPC Deck is used to draw Target Cards for NPCs, for their Actions, and when applying negative [Status Conditions](./01_PlayerGuide_Full.md#status-conditions). The World Deck is used to make social checks, and to draw Target Cards representing items and objects in the world. Reshuffle the NPC Deck before each Combat. Reshuffle the World Deck
+empty. 
 
 Most NPCs won't stick around long enough to use a deck completely, and
 therefore won't shuffle prematurely, which would invoke Lower Hand on Checks.

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -392,7 +392,7 @@ described in the guide or in a Power mechanic.
 
 ### Saves
 
-Saves occur when a character is attempting to resist or shrug off a negative effect(see
+Saves occur when a character is attempting to resist or shrug off a negative effect (see
 [Full Player Guide](./01_PlayerGuide_Full.md#saves) for more info). Certain Powers,
 events, or encounters may force a character to make a Save. 
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,7 +7,7 @@ hide:
 
 This repository establishes the version history of the Deck of Adventures tabletop
 roleplaying game. A magical world awaits, where Players come first. In Deck of
-Adventure, it’s your turn, your choice.
+Adventures, it’s your turn, your choice.
 
 Deck of Adventures is a collaborative roleplaying system, built with an open source 
 ethos. Please vist our


### PR DESCRIPTION
Addressing the following Issues: 

- [x] Closes #104 
- [x] Closes #110 
- [x] Closes #111 
- [x] Closes #130 
- [x] Closes #143 

Additional minor fixes:
- PGB outdated reference
- Removed Minion Deck for GMs, calling it NPC Deck
- Clarifying character instead of Player on held turns
- Updated Status Conditions to force Saves instead of Checks