### PR TITLE
New Powers, Vulnys, and Minor Edits to PGF and GM Guide

### DIFF
--- a/automation/_input/07_PCs.yaml
+++ b/automation/_input/07_PCs.yaml
@@ -1,0 +1,826 @@
+Template:               # must be unique
+  Type: One of          # Dealer, Boss, NPC, Companion
+  Level: X              # Dealers: XP progression, NPCs/Boss: Threat
+  HP: X                 # Required field
+  AP: X                 # 0 is default if blank
+  AR: X                 # Required field
+  PP: X                 # Required field
+  Speed: X              # Optional, default 6
+  Attribs:              # List only Non-zero
+    AGL: ±X             # + is implied if not explicit
+    CON: ±X             #
+    GUT: ±X             #
+    INT: ±X             #
+    STR: ±X             #
+    VIT: ±X             #
+  Skills:               # List if different from corresponding Attrib
+    Finesse: ±X         #
+    Stealth: ±X         #
+    Bluffing: ±X        #
+    Performance: ±X     #
+    Knowledge: ±X       #
+    Investigation: ±X   #
+    Detection: ±X       #
+    Craft: ±X           #
+    Athletics: ±X       #
+    Brute: ±X           #
+  Powers:               # Include Powers/Vulnerabilities names as list
+    Example: Option     # Add as key:value when the power allows options
+  Phases:               # Only for bosses
+    One:                #
+      HP: X             #
+      Allies: X         # List of who appears. If multiple of same, list multiple times
+  Description: Descrip  # Full descriptive text
+
+Clubs1:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Defender
+  Level: 1
+  Primary_Skill: STR
+  HP: 6
+  AP: 2
+  PP: 2
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 1
+    CON: 0
+    GUT: 0
+    INT: 0
+    STR: 2
+    VIT: 1
+  Skills:
+    Finesse: 1
+    Stealth: 1
+    Athletics: 2
+    Brute: 2
+  Powers:
+    - Attack, Weapon
+    - Attack, Vengeance
+    - Momentum
+    - Shield, Self
+    - Oath
+    - Bloodthirsty
+
+Clubs2:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Defender
+  Level: 2
+  Primary_Skill: STR
+  HP: 7
+  AP: 2
+  PP: 3
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 1
+    CON: 0
+    GUT: 0
+    INT: 0
+    STR: 2
+    VIT: 1
+  Skills:
+    Finesse: 1
+    Stealth: 1
+    Athletics: 2
+    Brute: 2
+  Powers:
+    - Attack, Weapon
+    - Attack, Vengeance
+    - Momentum
+    - Momentum Aura
+    - Shield, Self
+    - Oath
+    - Bloodthirsty
+
+Clubs3:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Defender
+  Level: 3
+  Primary_Skill: STR
+  HP: 8
+  AP: 2
+  PP: 5
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 1
+    CON: 0
+    GUT: 0
+    INT: 0
+    STR: 2
+    VIT: 1
+  Skills:
+    Finesse: 1
+    Stealth: 1
+    Athletics: 2
+    Brute: 2
+  Powers:
+    - Attack, Weapon
+    - Attack, Vengeance
+    - Attack, Charge
+    - Momentum
+    - Momentum Aura
+    - Shield, Self
+    - Oath
+    - Bloodthirsty
+
+Diamonds1:
+  Type: PC
+  Pronouns: "She/Her"
+  Role: Caster
+  Level: 1
+  Primary_Skill: INT
+  HP: 6
+  AP: 0
+  PP: 3
+  AR: 3
+  Speed: 4
+  Attribs:
+    AGL: 0
+    CON: 0
+    GUT: 0
+    INT: 2
+    STR: -2
+    VIT: 1
+  Skills:
+    Bluffing: 1
+    Knowledge: 2
+    Investigation: 2
+    Athletics: -2
+    Brute: -2
+  Powers:
+    - Attack, Mystic
+    - Attack, Mystic Cone
+    - Attack, Mystic Entangle
+    - Lucky
+    - Frail Form
+    - Weak, Major
+
+Diamonds2:
+  Type: PC
+  Pronouns: "She/Her"
+  Role: Caster
+  Level: 2
+  Primary_Skill: INT
+  HP: 7
+  AP: 0
+  PP: 4
+  AR: 3
+  Speed: 4
+  Attribs:
+    AGL: 0
+    CON: 0
+    GUT: 0
+    INT: 2
+    STR: -2
+    VIT: 1
+  Skills:
+    Bluffing: 2
+    Knowledge: 2
+    Investigation: 2
+    Athletics: -2
+    Brute: -2
+  Powers:
+    - Attack, Mystic
+    - Attack, Mystic Cone
+    - Attack, Mystic Entangle
+    - Lucky
+    - Scrying
+    - Frail Form
+    - Weak, Major
+
+Diamonds3:
+  Type: PC
+  Pronouns: "She/Her"
+  Role: Caster
+  Level: 3
+  Primary_Skill: INT
+  HP: 8
+  AP: 0
+  PP: 6
+  AR: 3
+  Speed: 4
+  Attribs:
+    AGL: 0
+    CON: 0
+    GUT: 0
+    INT: 2
+    STR: -2
+    VIT: 1
+  Skills:
+    Bluffing: 2
+    Knowledge: 2
+    Investigation: 2
+    Athletics: -2
+    Brute: -2
+  Powers:
+    - Attack, Mystic
+    - Attack, Mystic Cone
+    - Attack, Mystic Entangle
+    - Lucky
+    - Scrying
+    - Illusion
+    - Frail Form
+    - Weak, Major
+
+Hearts1:
+  Type: PC
+  Pronouns: "They/Them"
+  Role: Support
+  Level: 1
+  Primary_Skill: GUT
+  HP: 4
+  AP: 0
+  PP: 6
+  AR: 3
+  Speed: 6
+  Attribs:
+    AGL: -1
+    CON: 0
+    GUT: 2
+    INT: 0
+    STR: 0
+    VIT: -1
+  Skills:
+    Finesse: -1
+    Stealth: -1
+    Bluffing: 1
+    Detection: 2
+    Craft: 2
+  Powers:
+    - Lend Aid
+    - Attack, Mystic
+    - Attack, Mystic Entangle
+    - Heal
+    - Shield, Others
+    - Outsider
+    - Frail, Minor
+    - Clumsy, Minor
+
+Hearts2:
+  Type: PC
+  Pronouns: "They/Them"
+  Role: Support
+  Level: 2
+  Primary_Skill: GUT
+  HP: 6
+  AP: 0
+  PP: 6
+  AR: 3
+  Speed: 6
+  Attribs:
+    AGL: -1
+    CON: 0
+    GUT: 2
+    INT: 0
+    STR: 0
+    VIT: 0
+  Skills:
+    Finesse: -1
+    Bluffing: 1
+    Detection: 2
+    Craft: 2
+  Powers:
+    - Lend Aid
+    - Attack, Mystic
+    - Attack, Mystic Entangle
+    - Heal
+    - Shield, Others
+    - Outsider
+    - Clumsy, Minor
+
+Hearts3:
+  Type: PC
+  Pronouns: "They/Them"
+  Role: Support
+  Level: 3
+  Primary_Skill: GUT
+  HP: 7
+  AP: 0
+  PP: 8
+  AR: 3
+  Speed: 6
+  Attribs:
+    AGL: -1
+    CON: 0
+    GUT: 2
+    INT: 0
+    STR: 0
+    VIT: 0
+  Skills:
+    Finesse: -1
+    Bluffing: 1
+    Detection: 2
+    Craft: 2
+  Powers:
+    - Lend Aid
+    - Attack, Mystic
+    - Attack, Mystic Entangle
+    - Heal
+    - Shield, Others
+    - Lend Vigor
+    - Outsider
+    - Clumsy, Minor
+
+Spades1:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Martial
+  Level: 1
+  Primary_Skill: AGL
+  HP: 5
+  AP: 0
+  PP: 4
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 2
+    CON: 0
+    GUT: 1
+    INT: 0
+    STR: 0
+    VIT: 0
+  Skills:
+    Finesse: 2
+    Stealth: 2
+    Investigation: 1
+    Detection: 1
+    Craft: 1
+  Powers:
+    - Attack, Weapon
+    - Attack, Charge
+    - Attack, Sweep
+    - Stealthy Surprise
+    - Outsider
+    - Eye for an Eye
+
+Spades2:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Martial
+  Level: 2
+  Primary_Skill: AGL
+  HP: 7
+  AP: 0
+  PP: 4
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 2
+    CON: 0
+    GUT: 1
+    INT: 0
+    STR: 0
+    VIT: 1
+  Skills:
+    Finesse: 2
+    Stealth: 2
+    Investigation: 1
+    Detection: 1
+    Craft: 1
+  Powers:
+    - Attack, Weapon
+    - Attack, Charge
+    - Attack, Sweep
+    - Stealthy Surprise
+    - Stealth in the Shadows
+    - Outsider
+    - Eye for an Eye
+
+Spades3:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Martial
+  Level: 3
+  Primary_Skill: AGL
+  HP: 8
+  AP: 0
+  PP: 4
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 2
+    CON: 0
+    GUT: 1
+    INT: 0
+    STR: 0
+    VIT: 1
+  Skills:
+    Finesse: 2
+    Stealth: 2
+    Bluffing: 1
+    Investigation: 1
+    Detection: 1
+    Craft: 1
+  Powers:
+    - Attack, Weapon
+    - Attack, Charge
+    - Attack, Sweep
+    - Attack, Vengeance
+    - Stealthy Surprise
+    - Stealth in the Shadows
+    - Outsider
+    - Eye for an Eye
+
+Crusader1:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Defender
+  Level: 1
+  Primary_Skill: STR
+  HP: 6
+  AP: 2
+  PP: 2
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 1
+    CON: 0
+    GUT: 0
+    INT: 0
+    STR: 2
+    VIT: 1
+  Skills:
+    Finesse: 1
+    Stealth: 1
+    Athletics: 2
+    Brute: 2
+  Powers:
+    - Attack, Weapon
+    - Attack, Vengeance
+    - Momentum
+    - Shield, Self
+    - Oath
+    - Savior
+
+Crusader2:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Defender
+  Level: 2
+  Primary_Skill: STR
+  HP: 7
+  AP: 2
+  PP: 3
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 1
+    CON: 0
+    GUT: 0
+    INT: 0
+    STR: 2
+    VIT: 1
+  Skills:
+    Finesse: 1
+    Stealth: 1
+    Detection: 1
+    Athletics: 2
+    Brute: 2
+  Powers:
+    - Attack, Weapon
+    - Attack, Vengeance
+    - Aura of Defensive Damage
+    - Shield, Self
+    - Momentum
+    - Battlecharged
+    - Oath
+    - Savior
+
+Crusader3:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Defender
+  Level: 3
+  Primary_Skill: STR
+  HP: 8
+  AP: 2
+  PP: 6
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 1
+    CON: 0
+    GUT: 0
+    INT: 0
+    STR: 2
+    VIT: 1
+  Skills:
+    Finesse: 1
+    Stealth: 1
+    Detection: 1
+    Athletics: 2
+    Brute: 2
+  Powers:
+    - Attack, Weapon
+    - Attack, Vengeance
+    - Aura of Defensive Damage
+    - Aura of Regeneration
+    - Shield, Self
+    - Staggering Blow
+    - Momentum
+    - Oath
+    - Savior
+
+Summoner1:
+  Type: PC
+  Pronouns: "She/Her"
+  Role: Caster
+  Level: 1
+  Primary_Skill: INT
+  HP: 6
+  AP: 0
+  PP: 3
+  AR: 3
+  Speed: 6
+  Attribs:
+    AGL: 0
+    CON: 0
+    GUT: 0
+    INT: 2
+    STR: -2
+    VIT: 1
+  Skills:
+    Bluffing: 1
+    Knowledge: 2
+    Investigation: 2
+    Athletics: -2
+    Brute: -2
+  Powers:
+    - Attack, Mystic
+    - Attack, Mystic Cone
+    - Attack, Mystic Entangle
+    - Lucky
+    - Wanted
+    - Weak, Major
+
+Summoner2:
+  Type: PC
+  Pronouns: "She/Her"
+  Role: Caster
+  Level: 2
+  Primary_Skill: INT
+  HP: 7
+  AP: 0
+  PP: 5
+  AR: 3
+  Speed: 6
+  Attribs:
+    AGL: 0
+    CON: 0
+    GUT: 0
+    INT: 2
+    STR: -2
+    VIT: 1
+  Skills:
+    Bluffing: 2
+    Knowledge: 2
+    Investigation: 2
+    Athletics: -2
+    Brute: -2
+  Powers:
+    - Attack, Mystic
+    - Attack, Mystic Cone
+    - Attack, Mystic Entangle
+    - Summon Creature
+    - Lucky
+    - Wanted
+    - Weak, Major
+
+Summoner3:
+  Type: PC
+  Pronouns: "She/Her"
+  Role: Caster
+  Level: 3
+  Primary_Skill: INT
+  HP: 8
+  AP: 0
+  PP: 5
+  AR: 3
+  Speed: 6
+  Attribs:
+    AGL: 0
+    CON: 0
+    GUT: 0
+    INT: 2
+    STR: -2
+    VIT: 1
+  Skills:
+    Bluffing: 1
+    Knowledge: 2
+    Investigation: 2
+    Athletics: -2
+    Brute: -2
+  Powers:
+    - Attack, Mystic
+    - Attack, Mystic Cone
+    - Attack, Mystic Entangle
+    - Summon Creature
+    - Life Link
+    - Phase Swap
+    - Lucky
+    - Wanted
+    - Weak, Major
+
+Alchemist1:
+  Type: PC
+  Pronouns: "They/Them"
+  Role: Support
+  Level: 1
+  Primary_Skill: GUT
+  HP: 5
+  AP: 0
+  PP: 2
+  AR: 3
+  Speed: 6
+  Attribs:
+    AGL: -2
+    CON: 0
+    GUT: 2
+    INT: 0
+    STR: 0
+    VIT: 0
+  Skills:
+    Finesse: -2
+    Stealth: -2
+    Bluffing: 1
+    Detection: 2
+    Craft: 2
+  Powers:
+    - Lend Aid
+    - Attack, Mystic
+    - Shield, Others
+    - Cowardly Ally
+    - Clumsy, Major
+
+Alchemist2:
+  Type: PC
+  Pronouns: "They/Them"
+  Role: Support
+  Level: 2
+  Primary_Skill: GUT
+  HP: 6
+  AP: 0
+  PP: 4
+  AR: 3
+  Speed: 6
+  Attribs:
+    AGL: -2
+    CON: 0
+    GUT: 2
+    INT: 0
+    STR: 0
+    VIT: 0
+  Skills:
+    Finesse: -2
+    Stealth: -1
+    Bluffing: 1
+    Detection: 2
+    Craft: 2
+  Powers:
+    - Lend Aid
+    - Attack, Mystic
+    - Shield, Others
+    - Create Potion
+    - Cowardly Ally
+    - Clumsy, Major
+
+Alchemist3:
+  Type: PC
+  Pronouns: "They/Them"
+  Role: Support
+  Level: 2
+  Primary_Skill: GUT
+  HP: 7
+  AP: 0
+  PP: 6
+  AR: 3
+  Speed: 6
+  Attribs:
+    AGL: -2
+    CON: 0
+    GUT: 2
+    INT: 0
+    STR: 0
+    VIT: 0
+  Skills:
+    Finesse: -2
+    Stealth: -2
+    Bluffing: 1
+    Detection: 2
+    Craft: 2
+  Powers:
+    - Lend Aid
+    - Attack, Mystic
+    - Shield, Others
+    - Create Potion
+    - Create Poison
+    - Potent Brew
+    - Cowardly Ally
+    - Clumsy, Major
+
+Assassin1:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Martial
+  Level: 1
+  Primary_Skill: AGL
+  HP: 5
+  AP: 0
+  PP: 2
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 2
+    CON: 0
+    GUT: 1
+    INT: 1
+    STR: 0
+    VIT: 0
+  Skills:
+    Finesse: 2
+    Stealth: 2
+    Knowledge: 1
+    Investigation: 2
+    Detection: 1
+    Craft: 1
+  Powers:
+    - Attack, Weapon
+    - Attack, Charge
+    - Stealthy Surprise
+    - Vendetta
+    - Eye for an Eye
+
+Assassin2:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Martial
+  Level: 2
+  Primary_Skill: AGL
+  HP: 6
+  AP: 0
+  PP: 3
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 2
+    CON: 0
+    GUT: 1
+    INT: 1
+    STR: 0
+    VIT: 0
+  Skills:
+    Finesse: 2
+    Stealth: 2
+    Knowledge: 1
+    Investigation: 2
+    Detection: 1
+    Craft: 1
+  Powers:
+    - Attack, Weapon
+    - Attack, Charge
+    - Stealthy Surprise
+    - Stealth's Call
+    - Hidden Strike
+    - Vendetta
+    - Eye for an Eye
+
+Assassin3:
+  Type: PC
+  Pronouns: "He/Him"
+  Role: Martial
+  Level: 3
+  Primary_Skill: AGL
+  HP: 7
+  AP: 0
+  PP: 5
+  AR: 2
+  Speed: 6
+  Attribs:
+    AGL: 2
+    CON: 0
+    GUT: 1
+    INT: 1
+    STR: 0
+    VIT: 0
+  Skills:
+    Finesse: 2
+    Stealth: 2
+    Knowledge: 1
+    Investigation: 2
+    Detection: 1
+    Craft: 1
+  Powers:
+    - Attack, Weapon
+    - Attack, Charge
+    - Stealthy Surprise
+    - Stealth's Call
+    - Hidden Strike
+    - Vanishing Step
+    - Keen Eye
+    - Vendetta
+    - Eye for an Eye

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -397,7 +397,7 @@ Some Status Conditions will impact a character over time. The duration of each C
 is listed in the Power or effect that causes it.
 
 1. **Stunned** If a Dealer is hit by a critical attack, they make a DR 3 CON
-Save at the start of their turn vs their own TC. If failed, they may either move or
+Save at the start of their turn. If failed, they may either move or
 make one Action on their turn, not both. Some creatures can cause the Stunned Condition
 as part of their attacks.
 

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -544,17 +544,14 @@ represents a short 30-minute break, where characters may be catching
 their breath or healing their wounds. A Full Rest is an 8-hour period of time where
 characters get some sleep and recover from a long day.
 
-During a Quick Rest, each player who is resting draw from their deck using Rest Cards.
+During a Quick Rest, each player who is resting draws from their deck using Rest Cards.
 Players start with a number of Rest Cards equal to their maximum Health.
-Each Rest Card can be used as a DR 3 draw against one's own target card. On a miss,
+Each Rest Card can be used as a DR 3 draw against one's own target card without modifiers. On a miss,
 recover one HP or PP, your choice. On a success, recover two total points across HP and
 PP, your choice.
 
-To recover Armor Points, a player may make a Craft or Knowledge
-Skill check of DR 7 minus the number of points they are attempting to recover. If
-missed, a player may retry by attempting to recover one fewer AP.
 At the end of a Quick Rest, shuffle the discard pile and draw 10 plus twice Vitality
-back into your deck.
+back into your deck. A player can only gain the benefits of a Quick Rest twice per Full Rest.
 
 After completing a Full Rest, shuffle your discard pile back into your deck, along
 with any Aces from your hand. Add both Jokers to your hand as Fate Cards if they were

--- a/docs/src/1_Mechanics/01_PlayerGuide_Full.md
+++ b/docs/src/1_Mechanics/01_PlayerGuide_Full.md
@@ -14,8 +14,8 @@ guides the group in a meaningful way.
 
 Choosing which Tabletop Roleplaying Game (TTRPG) to play is an important step when
 starting an adventure and different game systems are better for different things.
-Common game systems include Dungeons and Dragons 5th Edition (5e) and Savage Worlds
-Adventure Edition (SWADE); rules, supplements, and other materials for game systems can
+Common game systems range from high fantasy to space-faring, typically using many-sided dice;
+rules, supplements, and other materials for various TTRPG game systems can
 be found in published volumes and elsewhere online. Deck of Adventures sets itself
 apart by swapping out dedicated many-sided dice for a standard deck of playing cards.
 While other TTRPGs rely on using dice to determine the results of an uncertain action,
@@ -45,8 +45,7 @@ Cards, even when shuffling the deck.
 
 3. Players will use their deck to do most anything; it represents their character's
 stamina until they complete a Rest. When the Action Deck is empty and a player has to
-shuffle between rests, they draw with the
-[Lower Hand (1+)](./01_PlayerGuide_Full.md#upper-and-lower-hand) until they would
+shuffle between rests, they suffer from [Fatigue](./01_PlayerGuide_Full.md#upper-and-lower-hand) until they would
 shuffle when resting.
 
 ## Fate Cards
@@ -114,7 +113,7 @@ and allow you to add that number to the DR when making a Check.
     - Brute (Fight)
    <!-- - Intimidation -->
 - Vitality VIT
-   <!-- - Vitality Skill to add later -->
+   <!-- - Grit -->
 
 Each skill is generally related to a domain of expertise a character may possess. A GM
 might call for a Check using a specific Skill, but you can always ask if another
@@ -288,7 +287,7 @@ initiator's TC. Rules that describe a
  fail individually.
 
 **For example,** Xena attempts to convince Jonas of something (either truthfully or
-with deception), they would use their Bluffing Mod of +1, setting the DR to 2 (3-1).
+with deception), they would use their Bluffing Mod of +2, setting the DR to 2 (3-1).
 They draw a TC of 3 of Diamonds, permitting a card between A and 6. Jonas draws an 8 of
 Spades with a +1 Modifier to Detection and reports a 7, still outside the DR. Xena would
 successfully convince Jonas of something in this scenario.
@@ -398,7 +397,7 @@ Some Status Conditions will impact a character over time. The duration of each C
 is listed in the Power or effect that causes it.
 
 1. **Stunned** If a Dealer is hit by a critical attack, they make a DR 3 CON
-Save at the start of their turn vs their  own TC. If failed, they may either move or
+Save at the start of their turn vs their own TC. If failed, they may either move or
 make one Action on their turn, not both. Some creatures can cause the Stunned Condition
 as part of their attacks.
 
@@ -433,15 +432,15 @@ Hand. A Dealer makes a DR 3 Strength Save as a Free Action at the end of their t
 attempt to end the freeze.
 
 9. **Suffocating** At the beginning of their turn, a Dealer makes a DR 3 VIT Save. On
-failure, take 2 damage. On a success, take 1 damage.
+failure, take 2 damage bypassing AP. On a success, take 1 damage.
 
-10. **Charmed** At the end of their turn or whenever taking damage, A Dealer makes a DR
+10. **Charmed** At the start of their turn or whenever taking damage, a Dealer makes a DR
 3 GUT Save. On failure, they may not take actions against the interests of the creature
 that caused the condition. Another creature may use a Major action to end this effect.
 This effects ends automatically if the target is damaged by the creature that caused
 the condition.
 
-11. **Enthralled** At the end of their turn or whenever taking damage, A Dealer makes a
+11. **Enthralled** At the start of their turn or whenever taking damage, a Dealer makes a
 DR 3 CON Save. On failure, they must move up to their Speed and/or perform 1 Major
 Action available to them, as directed by the creature that caused the condition.
 Another creature may use a Major action to end this effect. This effects ends
@@ -550,8 +549,8 @@ Players start with a number of Rest Cards equal to their maximum Health.
 Each Rest Card can be used as a DR 3 draw against one's own target card. On a miss,
 recover one HP or PP, your choice. On a success, recover two total points across HP and
 PP, your choice.
-To
-recover Armor Points, a player may make a Craft or Knowledge
+
+To recover Armor Points, a player may make a Craft or Knowledge
 Skill check of DR 7 minus the number of points they are attempting to recover. If
 missed, a player may retry by attempting to recover one fewer AP.
 At the end of a Quick Rest, shuffle the discard pile and draw 10 plus twice Vitality

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -723,9 +723,7 @@ the standard recommendation is to use a system based on rare metals. Gold,
 Silver, and Copper Pieces are useful breakdowns, and can be modified as needed to
 fit your setting.
 By default, currencies are at a 1:10 ratio with the next-most valuable counterpart:
-1 Gold
-Piece (gp) = 10 Silver Pieces (sp), and 1 Silver Piece = 10 Copper Pieces
-(cp). When creating your own currency, use the below tables as a reference
+1 Platinum Piece (pp) = 10 Gold Pieces(gp), 1 Gold Piece = 10 Silver Pieces (sp), and 1 Silver Piece = 10 Copper Pieces (cp). When creating your own currency, use the below tables as a reference
 for adapting these items to your setting.
 
 The GM can grant currency as a reward for completing an Adventure, defeating
@@ -780,10 +778,10 @@ quality of that weapon determines how much damage.
 
 | Damage | Descriptor | Average Cost |
 | ------ | ---------- | ------------ |
-| 1      | Standard   | 5 gp         |
-| 2      | Improved   | 500 gp       |
-| 3      | Heroic     | 2,500 gp     |
-| 4      | Legendary  | 5,000 gp     |
+| 1      | Standard   | 15 sp        |
+| 2      | Improved   | 25 gp        |
+| 3      | Heroic     | 25 pp        |
+| 4      | Legendary  | 100 pp       |
 
 Characters with high quality weapons are able to deal damage quickly, so keep
 this in mind when balancing Encounters or granting Players loot as they Level
@@ -809,12 +807,12 @@ Agility, Finesse, and Stealth Checks at Lower Hand.
 | AR     | Armor Type  | AP    | Prerequisite  | Average Cost |
 | ------ | ----------  | ----- | ------------  | -----------  |
 | 3      | Unarmored   | 0     | -             | -            |
-| 3      | Light       | 0     | -             | 5 gp         |
-| 2      | Medium      | 0     | -             | 25 gp        |
-| 2      | Fortified   | 1     | Strength ≥ 0  | 100 gp       |
-| 1      | Heavy       | 2     | Strength ≥ 1  | 500 gp       |
-| 1      | Massive     | 3     | Strength ≥ 2  | 1500 gp      |
-| 1      | Gleaming    | 2     | Agility ≥ 3   | 1500 gp      |
+| 3      | Light       | 0     | -             | 5 sp         |
+| 2      | Medium      | 0     | -             | 20 sp        |
+| 2      | Fortified   | 1     | Strength ≥ 0  | 15 gp        |
+| 1      | Heavy       | 2     | Strength ≥ 1  | 50 gp        |
+| 1      | Massive     | 3     | Strength ≥ 2  | 20 pp        |
+| 1      | Gleaming    | 2     | Agility ≥ 3   | 100 pp       |
 
 Characters may start with Light Armor at Level 1, but must acquire other armor over the
 course of their Adventures, either through purchase or reward.
@@ -829,9 +827,9 @@ in varying quality.
 
 | AP | Descriptor | Average Cost |
 | -- | ---------- | ------------ |
-| 1  | Standard   | 5 gp         |
-| 2  | Hardened   | 200 gp       |
-| 3  | Impervious | 1,500 gp     |
+| 1  | Standard   | 5 sp         |
+| 2  | Hardened   | 10 gp        |
+| 3  | Impervious | 25 pp        |
 
 ### General Items
 
@@ -844,19 +842,19 @@ costs.
 
 | Item Name      | Cost  |
 | -------------- | ----- |
-| Hammer         | 5 sp  |
-| Backpack       | 8 sp  |
-| Empty Vial     | 2 sp  |
-| Canvas Pouch   | 2 sp  |
-| Tent           | 1 gp  |
-| Torches        | 5 sp  |
-| Flint & Tinder | 5 sp  |
-| Bedroll        | 8 sp  |
-| Rations Kit    | 5 sp  |
-| Flask          | 1 gp  |
-| Lantern        | 2 gp  |
-| Mirror         | 1 gp  |
-| Crowbar        | 1 gp  |
+| Hammer         | 5 cp  |
+| Backpack       | 8 cp  |
+| Empty Vial     | 2 cp  |
+| Canvas Pouch   | 2 cp  |
+| Tent           | 1 sp  |
+| Torches        | 5 cp  |
+| Flint & Tinder | 5 cp  |
+| Bedroll        | 8 cp  |
+| Rations Kit    | 5 cp  |
+| Flask          | 1 sp  |
+| Lantern        | 2 sp  |
+| Mirror         | 1 sp  |
+| Crowbar        | 1 sp  |
 
 ### Tools
 
@@ -874,19 +872,19 @@ in some settings some professions' tools may be harder to find.
 
 | Profession Name    | Cost   |
 | ------------------ | ------ |
-| Blacksmith         | 5 gp   |
-| Locksmith          | 5 gp   |
-| Chef               | 3 gp   |
-| Carpenter          | 3 gp   |
-| Sailor             | 2 gp   |
-| Leatherworker      | 5 gp   |
-| Clothier           | 5 gp   |
-| Navigator          | 1 gp   |
-| Alchemist          | 3 gp   |
-| Herbalist          | 1 gp   |
-| Mountaineer        | 3 gp   |
-| Jeweler            | 10 gp  |
-| Cartographer       | 5 gp   |
+| Blacksmith         | 1 gp   |
+| Locksmith          | 1 gp   |
+| Chef               | 5 sp   |
+| Carpenter          | 5 sp   |
+| Sailor             | 2 sp   |
+| Leatherworker      | 5 sp   |
+| Clothier           | 1 gp   |
+| Navigator          | 2 sp   |
+| Alchemist          | 3 sp   |
+| Herbalist          | 2 sp   |
+| Mountaineer        | 3 sp   |
+| Jeweler            | 1 gp   |
+| Cartographer       | 1 gp   |
 
 ### Consumables
 
@@ -917,22 +915,22 @@ create your own Consumables and ask the Community for help as needed.
 
 | Consumable Name        | Cost  | Effect                                                                                    | Duration |
 | ---------------------- | ----- | ----------------------------------------------------------------------------------------- | -------- |
-| Potion of Healing      | 5 gp  | Regain 1 HP immediately                                                                   |          |
-| Potion of Water Breath | 10 gp | You are immune to the Suffocating Status Condition                                        | 1 hour   |
-| Potion of Extended Breath | 5 gp | Your ability to hold your breath is extended by 60 minutes                              | 1 hour   |
+| Potion of Healing      | 2 gp  | Regain 1 HP immediately                                                                   |          |
+| Potion of Water Breath | 5 gp | You are immune to the Suffocating Status Condition                                        | 1 hour   |
+| Potion of Extended Breath | 2 gp | Your ability to hold your breath is extended by 60 minutes                              | 1 hour   |
 | Potion of Strength     | 15 gp | Gain +1 to all Strength-based Checks                                                      | 1 min    |
 | Potion of Agility      | 15 gp | Gain +1 to all Agility-based Checks                                                       | 1 min    |
 | Potion of Conviction   | 15 gp | Gain +1 to all Conviction-based Checks                                                    | 1 min    |
 | Potion of Intelligence | 15 gp | Gain +1 to all Intelligence-based Checks                                                  | 1 min    |
 | Potion of Intuition    | 15 gp | Gain +1 to all Intuition-based Checks                                                     | 1 min    |
-| Potion of Vitality     | 25 gp | Gain +1 Maximum HP and +1 to all Vitality-based Checks                                    | 1 min    |
-| Charm of Efficiency    | 65 gp | You cannot draw with Upper or Lower Hand                                                  | 1 hour   |
-| Charm of True Aim      | 40 gp | All Attacks are made with Upper Hand                                                      | 1 hour   |
-| Charm of Amplification | 55 gp | All Upper Hand and Lower Hand effects are doubled                                         | 1 hour   |
-| Charm of Wounding      | 30 gp | When dealing damage with an Attack or Power, add +1 damage to the total                   | 1 hour   |
-| Hearty Stew            | 10 gp | Gain +1 HP and +1 to your Maximum HP                                                                | 8 hours  |
-| Focusing Beverage      | 10 gp | Gain +1 HP and +1 to your Maximum PP                                                                | 8 hours  |
-| Fortifying Feast       | 10 gp | Gain +3 AP immediately. For the duration, if you end your turn with 0 AP, return to 1 AP  | 8 hours  |
+| Potion of Vitality     | 2 pp  | Gain +1 Maximum HP and +1 to all Vitality-based Checks                                    | 1 min    |
+| Charm of Efficiency    | 6 pp  | You cannot draw with Upper or Lower Hand                                                  | 1 hour   |
+| Charm of True Aim      | 4 pp  | All Attacks are made with Upper Hand                                                      | 1 hour   |
+| Charm of Amplification | 5 pp  | All Upper Hand and Lower Hand effects are doubled                                         | 1 hour   |
+| Charm of Wounding      | 3 pp  | When dealing damage with an Attack or Power, add +1 damage to the total                   | 1 hour   |
+| Hearty Stew            | 1 pp | Gain +1 HP and +1 to your Maximum HP                                                                | 8 hours  |
+| Focusing Beverage      | 1 pp | Gain +1 HP and +1 to your Maximum PP                                                                | 8 hours  |
+| Fortifying Feast       | 1 pp | Gain +3 AP immediately. For the duration, if you end your turn with 0 AP, return to 1 AP  | 8 hours  |
 
 ### Magic Items
 

--- a/docs/src/1_Mechanics/02_GMGuide.md
+++ b/docs/src/1_Mechanics/02_GMGuide.md
@@ -719,11 +719,12 @@ weaknesses, and what actions they can take in combat.
 ### Standard Currency
 
 Every setting may have its own currency and economy, but in Deck of Adventures
-the standard recommendation is to use a system based on rare metals. Gold,
+the standard recommendation is to use a system based on rare metals or minerals. Diamond, Gold,
 Silver, and Copper Pieces are useful breakdowns, and can be modified as needed to
 fit your setting.
+
 By default, currencies are at a 1:10 ratio with the next-most valuable counterpart:
-1 Platinum Piece (pp) = 10 Gold Pieces(gp), 1 Gold Piece = 10 Silver Pieces (sp), and 1 Silver Piece = 10 Copper Pieces (cp). When creating your own currency, use the below tables as a reference
+1 Diamond Piece (dp) = 10 Gold Pieces(gp), 1 Gold Piece = 10 Silver Pieces (sp), and 1 Silver Piece = 10 Copper Pieces (cp). When creating your own currency, use the below tables as a reference
 for adapting these items to your setting.
 
 The GM can grant currency as a reward for completing an Adventure, defeating
@@ -780,8 +781,8 @@ quality of that weapon determines how much damage.
 | ------ | ---------- | ------------ |
 | 1      | Standard   | 15 sp        |
 | 2      | Improved   | 25 gp        |
-| 3      | Heroic     | 25 pp        |
-| 4      | Legendary  | 100 pp       |
+| 3      | Heroic     | 25 dp        |
+| 4      | Legendary  | 100 dp       |
 
 Characters with high quality weapons are able to deal damage quickly, so keep
 this in mind when balancing Encounters or granting Players loot as they Level
@@ -811,8 +812,8 @@ Agility, Finesse, and Stealth Checks at Lower Hand.
 | 2      | Medium      | 0     | -             | 20 sp        |
 | 2      | Fortified   | 1     | Strength ≥ 0  | 15 gp        |
 | 1      | Heavy       | 2     | Strength ≥ 1  | 50 gp        |
-| 1      | Massive     | 3     | Strength ≥ 2  | 20 pp        |
-| 1      | Gleaming    | 2     | Agility ≥ 3   | 100 pp       |
+| 1      | Massive     | 3     | Strength ≥ 2  | 20 dp        |
+| 1      | Gleaming    | 2     | Agility ≥ 3   | 100 dp       |
 
 Characters may start with Light Armor at Level 1, but must acquire other armor over the
 course of their Adventures, either through purchase or reward.
@@ -829,7 +830,7 @@ in varying quality.
 | -- | ---------- | ------------ |
 | 1  | Standard   | 5 sp         |
 | 2  | Hardened   | 10 gp        |
-| 3  | Impervious | 25 pp        |
+| 3  | Impervious | 25 dp        |
 
 ### General Items
 
@@ -923,14 +924,14 @@ create your own Consumables and ask the Community for help as needed.
 | Potion of Conviction   | 15 gp | Gain +1 to all Conviction-based Checks                                                    | 1 min    |
 | Potion of Intelligence | 15 gp | Gain +1 to all Intelligence-based Checks                                                  | 1 min    |
 | Potion of Intuition    | 15 gp | Gain +1 to all Intuition-based Checks                                                     | 1 min    |
-| Potion of Vitality     | 2 pp  | Gain +1 Maximum HP and +1 to all Vitality-based Checks                                    | 1 min    |
-| Charm of Efficiency    | 6 pp  | You cannot draw with Upper or Lower Hand                                                  | 1 hour   |
-| Charm of True Aim      | 4 pp  | All Attacks are made with Upper Hand                                                      | 1 hour   |
-| Charm of Amplification | 5 pp  | All Upper Hand and Lower Hand effects are doubled                                         | 1 hour   |
-| Charm of Wounding      | 3 pp  | When dealing damage with an Attack or Power, add +1 damage to the total                   | 1 hour   |
-| Hearty Stew            | 1 pp | Gain +1 HP and +1 to your Maximum HP                                                                | 8 hours  |
-| Focusing Beverage      | 1 pp | Gain +1 HP and +1 to your Maximum PP                                                                | 8 hours  |
-| Fortifying Feast       | 1 pp | Gain +3 AP immediately. For the duration, if you end your turn with 0 AP, return to 1 AP  | 8 hours  |
+| Potion of Vitality     | 2 dp  | Gain +1 Maximum HP and +1 to all Vitality-based Checks                                    | 1 min    |
+| Charm of Efficiency    | 6 dp  | You cannot draw with Upper or Lower Hand                                                  | 1 hour   |
+| Charm of True Aim      | 4 dp  | All Attacks are made with Upper Hand                                                      | 1 hour   |
+| Charm of Amplification | 5 dp  | All Upper Hand and Lower Hand effects are doubled                                         | 1 hour   |
+| Charm of Wounding      | 3 dp  | When dealing damage with an Attack or Power, add +1 damage to the total                   | 1 hour   |
+| Hearty Stew            | 1 dp | Gain +1 HP and +1 to your Maximum HP                                                                | 8 hours  |
+| Focusing Beverage      | 1 dp | Gain +1 HP and +1 to your Maximum PP                                                                | 8 hours  |
+| Fortifying Feast       | 1 dp | Gain +3 AP immediately. For the duration, if you end your turn with 0 AP, return to 1 AP  | 8 hours  |
 
 ### Magic Items
 

--- a/docs/src/1_Mechanics/04_Powers.yaml
+++ b/docs/src/1_Mechanics/04_Powers.yaml
@@ -923,7 +923,7 @@ Craft Light:
     Category:
         - Magic
     Description: Your skills let you conjure illusory effects.
-    Mechanic: Make a DR 3 Craft Check. On a Success you create an 8 space radiance of light for 15 minutes. On a Failure, the light only lasts for 1 round. You can create a temporary illusory object or infuse an existing object with this property. It can be covered and dimmed. Using a Minor action allows you to extinguish a light. If the light is more than 200 spaces away from you, it disappears
+    Mechanic: Make a DR 3 Craft Check. On a Success you create an Aura 6 space radiance of light for 15 minutes. On a Failure, the light only lasts for 1 round. You can create a temporary illusory object or infuse an existing object with this property. It can be covered and dimmed. Using a Minor action allows you to extinguish a light. If the light is more than 100 spaces away from you, it disappears
     Type: Minor
     XP: 2
     PP: 1
@@ -1074,7 +1074,7 @@ Aura of Defensive Damage:
         Role: Defender
         Level: 2
         Skill: Brute > 0
-    Range: 6
+    AOE: Aura 6
     Duration: 1 minute
 
 Aura of Regeneration:
@@ -1083,7 +1083,7 @@ Aura of Regeneration:
         - Aura
         - Combat
         - Crusader
-    Mechanic: Allied creatures within range gain the effects of your Aura. When they draw a Suited Hit or a Suited Miss, they regain 1 PP. This can only happen once per round. 
+    Mechanic: Allied creatures within range gain the effects of your Aura. When they draw a Suited Hit or a Suited Miss, they regain 1 PP, limited to 1 per round. 
     Description: It is often said that working together means supporting each other's weaknesses and strengths. In some cases amplifying others is the best strength of all. 
     XP: 2
     PP: 2
@@ -1116,4 +1116,3 @@ Staggering Blow:
         Trigger: On a successful hit, 
         Type: VIT
         Fail: they are Stunned
-        Succeed: no effect 

--- a/docs/src/1_Mechanics/04_Powers.yaml
+++ b/docs/src/1_Mechanics/04_Powers.yaml
@@ -18,6 +18,7 @@ Template: # Power name        # Must be unique
     Range: X                  # Integer of spaces. 0 for self, 1 for melee
     AOE: Shape X              # Aura, cone, or line followed by integer for size
     Target: X                 # Integer, # of targets
+    Duration: X               # String, to specify '1 hour' or '10 minutes' or '1 round'
     Options: X                # Optional Descrip of options. Replaced by selection.
     Save:                     # Separated here, merged in md
         Trigger: One of       # Once, On hit, On starting turn etc. Sentence start.
@@ -736,7 +737,6 @@ Stealth's Blessing:
     PP: [1,2]
     Prereq:
         Level: 2
-    Prereq:
         Skill: Stealth > 2
     Tags:
         - Stealth
@@ -918,4 +918,202 @@ Amplify Ally:
     PP: 0
     Description: Move the chess pieces on your board.
     Mechanic: Select one ally. They can immediately move up to 4 spaces and take one Action.  
-    
+
+Craft Light:
+    Category:
+        - Magic
+    Description: Your skills let you conjure illusory effects.
+    Mechanic: Make a DR 3 Craft Check. On a Success you create an 8 space radiance of light for 15 minutes. On a Failure, the light only lasts for 1 round. You can create a temporary illusory object or infuse an existing object with this property. It can be covered and dimmed. Using a Minor action allows you to extinguish a light. If the light is more than 200 spaces away from you, it disappears
+    Type: Minor
+    XP: 2
+    PP: 1
+    Prereq:
+        Role: 
+            - Caster
+            - Support
+        Skill: Craft > 0
+
+Hidden Strike: 
+    Type: Passive
+    Category: 
+        - Stealth
+        - Combat
+        - Assassin    
+    Mechanic: When attacking an enemy that is unaware of your presence or engaged with an ally within 1 space, you draw with Upper Hand. Any attacks that are successful deal +1 damage
+    Description: You move silently in the shadows, and are especially deadly when unseen. 
+    XP: 2
+    Prereq:
+        Role: Martial
+        Level: 2
+        Skill: Stealth > 0
+
+Vanishing Step: 
+    Type: Major
+    Category: 
+        - Movement
+        - Stealth
+        - Assassin
+    Mechanic: Choose a point you can see within 10 spaces of you. If the space is unoccupied, you appear there Hidden. If you attempt to occupy a space with another creature in it you are not Hidden
+    Description: Sometimes, moving in the shadows is easiest when no one knows where you're going.
+    XP: 2
+    PP: 2
+    Prereq:
+        Role: Martial
+        Level: 3
+        Skill: Stealth > 1
+        Power: Hidden Strike
+    Range: 10
+    Target: 1
+    Save:
+        Trigger: If the space is occupied, the creature occupying that space makes a 
+        Type: STR
+        Fail: they are pushed out of the way
+        Succeed: instead, choose a space within 1 space of the creature to appear. 
+
+Summon Creature:
+    Type: Major
+    Category:
+        - Companion
+        - Summoner
+    Mechanic: Summon a creature to assist you. This creature uses the 'Summoned Creature' stat block and is treated as a Companion for the duration. You choose the creature's form. 
+    Description: It's good to have a friend, even when you have to summon them from somewhere else. Who ever said no to a little extra help?
+    XP: 2
+    PP: 2
+    Prereq:
+        Role: Caster
+        Level: 2
+        Skill: Knowledge > 0
+    Duration: 1 hour
+
+Phase Swap:
+    Type: Minor
+    Category:
+        - Companion
+        - Movement
+        - Summoner
+    Mechanic: Use half your speed to swap spaces with a Summoned Creature 
+    Description: It can often be better to change places with a friendly creature. You'd prefer to be there, or they'd prefer to be here.
+    XP: 2
+    PP: 1
+    Prereq:
+        Role: Caster
+        Level: 3
+        Skill: Knowledge > 1
+        Power: Summon Creature
+    Range: 10
+
+Life Link: 
+    Type: Passive
+    Category: 
+        - Companion
+        - Summoner   
+    Mechanic: While you have at least one summoned creature active, when you take damage you can choose to apply that damage to your summoned creature instead.
+    Description: Channeling energy between friends can sometimes be mutually beneficial. Other times, it's simply beneficial.
+    XP: 2
+    Prereq:
+        Role: Caster
+        Level: 3
+        Skill: Knowledge > 1
+        Power: Summon Creature
+
+Create Potion:
+    Type: Major
+    Category:
+        - Recovery
+        - Alchemist
+    Mechanic: Create a Potion of Healing. After successfully completing a Quick Rest, you can exchange one Rest Card for a Potion of Healing without expending Power Points. All Potions created last until the end of your next Full Rest.
+    Description: It's always good to have some spare healing on hand. 
+    XP: 2
+    PP: 1
+    Prereq:
+        Role: Support
+        Level: 2
+        Skill: Craft > 0
+
+Create Poison:
+    Type: Major
+    Category:
+        - Combat
+        - Alchemist
+    Mechanic: Create a Poison Bottle. Apply to a Physical Weapon to force a DR 2 VIT Save, on a failure they take 1 damage bypassing AP. All Poison Bottles created last until the end of your next Full Rest.
+    Description: It's not wise to get on someone's bad side, especially when they have friends. 
+    XP: 2
+    PP: 1
+    Prereq:
+        Role: Support
+        Level: 3
+        Skill: Craft > 1
+        Power: Create Potion
+    Duration: 1 minute
+
+Potent Brew: 
+    Type: Passive
+    Category: 
+        - Recovery
+        - Alchemist   
+    Mechanic: When creating a consumable item, increase the effect by 1. 
+    Description: Sometimes its a matter of skill, other times its a matter of ingredients, but often making a potent brew requires both. 
+    XP: 2
+    Prereq:
+        Role: Support
+        Level: 3
+        Skill: Craft > 1
+        Power: Create Potion
+
+Aura of Defensive Damage:
+    Type: Minor
+    Category:
+        - Aura
+        - Combat
+        - Crusader
+    Mechanic: Allied creatures within range gain the effects of your Aura. When a creature is hit by a melee attack, the attacker takes 1 damage.   
+    Description: Protecting others from harm can be challenging when you can't be multiple places at once. Radiating an Aura helps.
+    XP: 2
+    PP: 1
+    Prereq:
+        Role: Defender
+        Level: 2
+        Skill: Brute > 0
+    Range: 6
+    Duration: 1 minute
+
+Aura of Regeneration:
+    Type: Minor
+    Category:
+        - Aura
+        - Combat
+        - Crusader
+    Mechanic: Allied creatures within range gain the effects of your Aura. When they draw a Suited Hit or a Suited Miss, they regain 1 PP. This can only happen once per round. 
+    Description: It is often said that working together means supporting each other's weaknesses and strengths. In some cases amplifying others is the best strength of all. 
+    XP: 2
+    PP: 2
+    Prereq:
+        Role: Defender
+        Level: 3
+        Skill: Brute > 1
+    Range: 6
+    Duration: 1 minute
+
+Staggering Blow: 
+    Type: Major
+    Category: 
+        - Combat
+        - Crusader
+    Mechanic: Make a Weapon Attack against a creature
+    Description: Getting something to stay still is just a matter of applying pressure in the right spot. Or hitting that spot really hard. 
+    XP: 2
+    PP: 1
+    Prereq:
+        Role: Defender
+        Level: 3
+        Skill: Brute > 1
+        Power: 
+            - Attack, Weapon
+            - Aura of Defensive Damage
+    Range: 1
+    Target: 1
+    Save:
+        Trigger: On a successful hit, 
+        Type: VIT
+        Fail: they are Stunned
+        Succeed: no effect 

--- a/docs/src/1_Mechanics/04_Powers.yaml
+++ b/docs/src/1_Mechanics/04_Powers.yaml
@@ -937,8 +937,7 @@ Hidden Strike:
     Type: Passive
     Category: 
         - Stealth
-        - Combat
-        - Assassin    
+        - Combat  
     Mechanic: When attacking an enemy that is unaware of your presence or engaged with an ally within 1 space, you draw with Upper Hand. Any attacks that are successful deal +1 damage
     Description: You move silently in the shadows, and are especially deadly when unseen. 
     XP: 2
@@ -946,14 +945,15 @@ Hidden Strike:
         Role: Martial
         Level: 2
         Skill: Stealth > 0
+    Tags:
+        - Assassin  
 
 Vanishing Step: 
     Type: Major
     Category: 
         - Movement
         - Stealth
-        - Assassin
-    Mechanic: Choose a point you can see within 10 spaces of you. If the space is unoccupied, you appear there Hidden. If you attempt to occupy a space with another creature in it you are not Hidden
+    Mechanic: Choose a point you can see within 10 spaces of you. If the space is unoccupied, you appear there Hidden. You cannot attempt to occupy a space that is occupied by another creature.
     Description: Sometimes, moving in the shadows is easiest when no one knows where you're going.
     XP: 2
     PP: 2
@@ -963,18 +963,13 @@ Vanishing Step:
         Skill: Stealth > 1
         Power: Hidden Strike
     Range: 10
-    Target: 1
-    Save:
-        Trigger: If the space is occupied, the creature occupying that space makes a 
-        Type: STR
-        Fail: they are pushed out of the way
-        Succeed: instead, choose a space within 1 space of the creature to appear. 
+    Tags:
+        - Assassin 
 
 Summon Creature:
     Type: Major
     Category:
         - Companion
-        - Summoner
     Mechanic: Summon a creature to assist you. This creature uses the 'Summoned Creature' stat block and is treated as a Companion for the duration. You choose the creature's form. 
     Description: It's good to have a friend, even when you have to summon them from somewhere else. Who ever said no to a little extra help?
     XP: 2
@@ -984,13 +979,13 @@ Summon Creature:
         Level: 2
         Skill: Knowledge > 0
     Duration: 1 hour
+    Tags:  
+        - Summoner
 
 Phase Swap:
     Type: Minor
     Category:
-        - Companion
         - Movement
-        - Summoner
     Mechanic: Use half your speed to swap spaces with a Summoned Creature 
     Description: It can often be better to change places with a friendly creature. You'd prefer to be there, or they'd prefer to be here.
     XP: 2
@@ -1001,12 +996,13 @@ Phase Swap:
         Skill: Knowledge > 1
         Power: Summon Creature
     Range: 10
+    Tags:  
+        - Summoner
 
 Life Link: 
     Type: Passive
     Category: 
-        - Companion
-        - Summoner   
+        - Companion  
     Mechanic: While you have at least one summoned creature active, when you take damage you can choose to apply that damage to your summoned creature instead.
     Description: Channeling energy between friends can sometimes be mutually beneficial. Other times, it's simply beneficial.
     XP: 2
@@ -1015,12 +1011,13 @@ Life Link:
         Level: 3
         Skill: Knowledge > 1
         Power: Summon Creature
+    Tags:  
+        - Summoner
 
 Create Potion:
     Type: Major
     Category:
-        - Recovery
-        - Alchemist
+        - Consumable
     Mechanic: Create a Potion of Healing. After successfully completing a Quick Rest, you can exchange one Rest Card for a Potion of Healing without expending Power Points. All Potions created last until the end of your next Full Rest.
     Description: It's always good to have some spare healing on hand. 
     XP: 2
@@ -1029,12 +1026,13 @@ Create Potion:
         Role: Support
         Level: 2
         Skill: Craft > 0
+    Tags:  
+        - Alchemist
 
 Create Poison:
     Type: Major
     Category:
-        - Combat
-        - Alchemist
+        - Consumable
     Mechanic: Create a Poison Bottle. Apply to a Physical Weapon to force a DR 2 VIT Save, on a failure they take 1 damage bypassing AP. All Poison Bottles created last until the end of your next Full Rest.
     Description: It's not wise to get on someone's bad side, especially when they have friends. 
     XP: 2
@@ -1045,13 +1043,15 @@ Create Poison:
         Skill: Craft > 1
         Power: Create Potion
     Duration: 1 minute
+    Tags:  
+        - Alchemist
+
 
 Potent Brew: 
     Type: Passive
     Category: 
-        - Recovery
-        - Alchemist   
-    Mechanic: When creating a consumable item, increase the effect by 1. 
+        - Consumable
+    Mechanic: When using a Power that creates a consumable, increase the damage healed or dealt by 1. 
     Description: Sometimes its a matter of skill, other times its a matter of ingredients, but often making a potent brew requires both. 
     XP: 2
     Prereq:
@@ -1059,13 +1059,15 @@ Potent Brew:
         Level: 3
         Skill: Craft > 1
         Power: Create Potion
+    Tags:  
+        - Alchemist
+
 
 Aura of Defensive Damage:
     Type: Minor
     Category:
-        - Aura
         - Combat
-        - Crusader
+        - Aura
     Mechanic: Allied creatures within range gain the effects of your Aura. When a creature is hit by a melee attack, the attacker takes 1 damage.   
     Description: Protecting others from harm can be challenging when you can't be multiple places at once. Radiating an Aura helps.
     XP: 2
@@ -1076,13 +1078,14 @@ Aura of Defensive Damage:
         Skill: Brute > 0
     AOE: Aura 6
     Duration: 1 minute
+    Tags:    
+        - Crusader
 
 Aura of Regeneration:
     Type: Minor
     Category:
-        - Aura
         - Combat
-        - Crusader
+        - Aura
     Mechanic: Allied creatures within range gain the effects of your Aura. When they draw a Suited Hit or a Suited Miss, they regain 1 PP, limited to 1 per round. 
     Description: It is often said that working together means supporting each other's weaknesses and strengths. In some cases amplifying others is the best strength of all. 
     XP: 2
@@ -1093,12 +1096,13 @@ Aura of Regeneration:
         Skill: Brute > 1
     Range: 6
     Duration: 1 minute
+    Tags:    
+        - Crusader
 
 Staggering Blow: 
     Type: Major
     Category: 
         - Combat
-        - Crusader
     Mechanic: Make a Weapon Attack against a creature
     Description: Getting something to stay still is just a matter of applying pressure in the right spot. Or hitting that spot really hard. 
     XP: 2
@@ -1116,3 +1120,5 @@ Staggering Blow:
         Trigger: On a successful hit, 
         Type: VIT
         Fail: they are Stunned
+    Tags: 
+        - Crusader

--- a/docs/src/1_Mechanics/04_Powers.yaml
+++ b/docs/src/1_Mechanics/04_Powers.yaml
@@ -18,7 +18,6 @@ Template: # Power name        # Must be unique
     Range: X                  # Integer of spaces. 0 for self, 1 for melee
     AOE: Shape X              # Aura, cone, or line followed by integer for size
     Target: X                 # Integer, # of targets
-    Duration: X               # String, to specify '1 hour' or '10 minutes' or '1 round'
     Options: X                # Optional Descrip of options. Replaced by selection.
     Save:                     # Separated here, merged in md
         Trigger: One of       # Once, On hit, On starting turn etc. Sentence start.
@@ -1033,7 +1032,7 @@ Create Poison:
     Type: Major
     Category:
         - Consumable
-    Mechanic: Create a Poison Bottle. Apply to a Physical Weapon to force a DR 2 VIT Save, on a failure they take 1 damage bypassing AP. All Poison Bottles created last until the end of your next Full Rest.
+    Mechanic: Create a Poison Bottle. Poison Bottle can be applied to a weapon. For 1 minute, all Weapon Attacks force a DR 2 VIT Save, on a failure they take 1 damage bypassing AP. All Poison Bottles created last until the end of your next Full Rest.
     Description: It's not wise to get on someone's bad side, especially when they have friends. 
     XP: 2
     PP: 1
@@ -1042,7 +1041,6 @@ Create Poison:
         Level: 3
         Skill: Craft > 1
         Power: Create Potion
-    Duration: 1 minute
     Tags:  
         - Alchemist
 

--- a/docs/src/1_Mechanics/05_Vulnerabilities.yaml
+++ b/docs/src/1_Mechanics/05_Vulnerabilities.yaml
@@ -42,26 +42,6 @@ Chaotic Companion:
     Prereq:
         Power: Creature Connection
 
-# Clumsy, Minor:
-#     Category: Stats
-#     XP: -1
-#     Prereq:
-#         Level: 0
-#     StatOverride: AGL -1
-#     Type: Vulny
-#     Description: You're clumsier than most.
-#     Mechanic: On character creation, you start with -1 AGL
-
-# Clumsy, Major:
-#     Category: Stats
-#     XP: -2
-#     Prereq:
-#         Level: 0
-#     StatOverride: AGL -2
-#     Type: Vulny 
-#     Description: You're clumsier than most.
-#     Mechanic: On character creation, you start with -2 AGL
-
 Oath:
     Category: Roleplay
     Description: a.k.a Vow, Code of Honor. You swore an oath to abide by a particular set of rules.
@@ -187,3 +167,98 @@ Wanted:
     Type: Vulny
     XP: [-1,-2]
 
+Clumsy, Minor:
+    Category: Stats
+    XP: -1
+    StatOverride: 
+        AGL: -1
+    Description: You're clumsier than most.
+    Mechanic: On character creation, you start with -1 AGL
+
+Clumsy, Major:
+    Category: Stats
+    XP: -2
+    StatOverride: 
+        AGL: -2
+    Description: You're clumsier than most.
+    Mechanic: On character creation, you start with -2 AGL
+
+Dumb, Minor:
+    Category: Stats
+    XP: -1
+    StatOverride: 
+        INT: -1
+    Description: You're dumber than most.
+    Mechanic: On character creation, you start with -1 INT
+
+Dumb, Major:
+    Category: Stats
+    XP: -2
+    StatOverride: 
+        INT: -2
+    Description: You're dumber than most.
+    Mechanic: On character creation, you start with -2 INT
+
+Counterintuitive, Minor:
+    Category: Stats
+    XP: -1
+    StatOverride: 
+        GUT: -1
+    Description: You're less intuitive than most.
+    Mechanic: On character creation, you start with -1 GUT
+
+Counterintuitive, Major:
+    Category: Stats
+    XP: -2
+    StatOverride:
+        GUT: -2
+    Description: You're less intuitive than most.
+    Mechanic: On character creation, you start with -2 GUT
+
+Frail, Minor:
+    Category: Stats
+    XP: -1
+    StatOverride: 
+        VIT: -1
+    Description: You're frailer than most.
+    Mechanic: On character creation, you start with -1 VIT
+
+Frail, Major:
+    Category: Stats
+    XP: -2
+    StatOverride: 
+        VIT: -2 
+    Description: You're frailer than most.
+    Mechanic: On character creation, you start with -2 VIT
+
+Uncertain, Minor:
+    Category: Stats
+    XP: -1
+    StatOverride: 
+        CON: -1
+    Description: You're less certain than most.
+    Mechanic: On character creation, you start with -1 CON
+
+Uncertain, Major:
+    Category: Stats
+    XP: -2
+    StatOverride: 
+        CON: -2 
+    Description: You're less certain than most.
+    Mechanic: On character creation, you start with -2 CON
+
+Weak, Minor:
+    Category: Stats
+    XP: -1
+    StatOverride: 
+        STR: -1
+    Description: You're weaker than most.
+    Mechanic: On character creation, you start with -1 STR
+
+Weak, Major:
+    Category: Stats
+    XP: -2
+    StatOverride: 
+        STR: -2 
+    Description: You're weaker than most.
+    Mechanic: On character creation, you start with -2 STR

--- a/docs/src/1_Mechanics/06_Bestiary.yaml
+++ b/docs/src/1_Mechanics/06_Bestiary.yaml
@@ -72,6 +72,19 @@ Wolf:
     - Attack, Weapon
     - Pack Tactics
 
+Summoned Creature:
+  Type: Companion
+  Level: 1
+  HP: 3
+  AR: 3
+  Attribs:
+    AGL: 1
+    STR: 1
+    INT: -1
+    CON: -1
+  Powers:
+    - Attack, Weapon
+
 Horse:
   Type: Companion
   Level: 1
@@ -86,7 +99,7 @@ Horse:
     - Attack, Weapon
     - Pack Tactics
 
-Wolf:
+Gray Wolf:
   Type: NPC
   HP: 2
   AR: 3
@@ -134,7 +147,6 @@ Vine Golem:
   Powers:
     - Attack, Weapon
     - Momentum
-
 
 Tree Golem:
   Type: Dealer
@@ -237,7 +249,6 @@ Mystic, Caster:
   HP: 5
   PP: 2
   AR: 3
-  PP: 3
   Attribs:
     AGL: -1
     CON: 1
@@ -255,7 +266,6 @@ Mystic, Caster:
 
 Sentinel, Martial:
   Type: Dealer
-  Level: 2
   Level: 2
   HP: 6
   AP: 0


### PR DESCRIPTION
In this PR, I...

- [x] Add new Powers across all Roles as part of the Archetype conversion into Skill Trees and create the 07_PCs.yaml input file with 4 Archetypes levels 1-3 #115 
- [x] Add 'Duration' as a new Key in the Powers YAML to indicate length of time a Power lasts
- [x] Add new Vulnys to assist with Stat Overrides for Character Creation when reducing an Attribute by -1 or -2 #160 
- [x] Update Player Guide Full with a modified reference to common TTRPG systems and update reference to Fatigue, along with other minor edits
- [x] Change Charmed and Enthralled to have saves that happen at the beginning of turn rather than end
- [x] Create a new currency (Diamond Pieces `dp`) to keep our rule of simple numbers in check, and modified all costs in GM guide to reflect this simpler methodology